### PR TITLE
Add linux support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,5 +10,8 @@
     "dbaeumer.vscode-eslint",
     "davidanson.vscode-markdownlint",
     "mike-co.import-sorter"
+  ],
+  "runArgs": [
+    "--privileged"
   ]
 }

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -26,7 +26,7 @@ An Electron application must follow a few setup steps in order to consume and us
 
 ## Linux Usage
 
-`ElectronMainAuthorization` uses the node package [Keytar](https://www.npmjs.com/package/keytar) to securely save refresh tokens to disk. This allows the client to automatically sign-in and receive a new access token between sessions. Keytar does this by using different native secure storage solutions depending on the operating system, and it uses libsecret on linux. In order to use keytar on linux, specifically Debian/Ubuntu,  `libsecret-1-dev` must be installed.
+`ElectronMainAuthorization` uses the node package [Keytar](https://www.npmjs.com/package/keytar) to securely save refresh tokens to disk. This allows the client to automatically sign-in and receive a new access token between sessions. Keytar does this by using different native secure storage solutions depending on the operating system, and it uses libsecret on linux. In order to use keytar on linux, specifically Debian/Ubuntu, `libsecret-1-dev` must be installed.
 
 If keytar is being used in a headless environment additional steps need to be taken. The following packages will need to be installed:
 
@@ -35,4 +35,4 @@ If keytar is being used in a headless environment additional steps need to be ta
 - gnome-keyring
 - xvfb
 
-Users will then need to start a dbus session and create a keyring password by running `dbus-run-session -- sh && echo 'keyringPassword' | gnome-keyring-daemon -r -d --unlock`. Then to actually run any apps that are using keytar you must prepend it with xvfb-run command in order to simulate a screen like so: `xvfb-run --auto-servernum --server-args='-screen 0, 1600x900x24' npm run start`. If running within a Docker container, make sure to add the `--privileged` argument when running the container.
+Users will then need to start a dbus session and create a keyring password by running `dbus-run-session -- sh` and then creating a keyring with `echo 'keyringPassword' | gnome-keyring-daemon -r -d --unlock`. Then to actually run any apps that are using keytar you must prepend it with xvfb-run command in order to simulate a screen like so: `xvfb-run --auto-servernum --server-args='-screen 0, 1600x900x24' npm run start`. If running within a Docker container, make sure to add the `--privileged` argument when running the container.

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -35,4 +35,4 @@ If keytar is being used in a headless environment additional steps need to be ta
 - gnome-keyring
 - xvfb
 
-Users will then need to start a dbus session and create a keyring password by running `dbus-run-session -- sh && echo 'keyringPassword' | gnome-keyring-daemon -r -d --unlock`. Then to actually run any apps that are using keytar you must prepend it with xvfb-run command in order to simulate a screen like so: `xvfb-run --auto-servernum --server-args='-screen 0, 1600x900x24' npm run start`.
+Users will then need to start a dbus session and create a keyring password by running `dbus-run-session -- sh && echo 'keyringPassword' | gnome-keyring-daemon -r -d --unlock`. Then to actually run any apps that are using keytar you must prepend it with xvfb-run command in order to simulate a screen like so: `xvfb-run --auto-servernum --server-args='-screen 0, 1600x900x24' npm run start`. If running within a Docker container, make sure to add the `--privileged` argument when running the container.

--- a/packages/electron/src/main/TokenStore.ts
+++ b/packages/electron/src/main/TokenStore.ts
@@ -32,9 +32,6 @@ export class ElectronTokenStore {
 
   /** Load token if available */
   public async load(): Promise<TokenResponse | undefined> {
-    if (process.platform === "linux")
-      return undefined;
-
     const userName = await this.getUserName();
     if (!userName)
       return;
@@ -50,9 +47,6 @@ export class ElectronTokenStore {
 
   /** Save token after signin */
   public async save(tokenResponse: TokenResponse): Promise<void> {
-    if (process.platform === "linux")
-      return undefined;
-
     const userName = await this.getUserName();
     if (!userName)
       return;
@@ -67,9 +61,6 @@ export class ElectronTokenStore {
 
   /** Delete token after signout */
   public async delete(): Promise<void> {
-    if (process.platform === "linux")
-      return undefined;
-
     const userName = await this.getUserName();
     if (!userName)
       return;

--- a/packages/electron/src/test/MainAuthorizationClient.test.ts
+++ b/packages/electron/src/test/MainAuthorizationClient.test.ts
@@ -19,9 +19,6 @@ chai.use(chaiAsPromised);
 
 describe("ElectronMainAuthorization Token Logic", () => {
   beforeEach(function () {
-    if (process.platform === "linux")
-      this.skip();
-
     sinon.restore();
     // Stub Electron calls
     sinon.stub(ElectronMainAuthorization.prototype, "setupIPCHandlers" as any);


### PR DESCRIPTION
Removed linux restrictions are updated the readme with information on how to run headless.

TODO: Decide how we want to handle setting up pipelines to be able to handle the correct headless environment.