### PR TITLE
Include issuerUrl in TokenStore key

### DIFF
--- a/common/changes/@itwin/node-cli-authorization/better-token-store-key_2022-04-27-15-05.json
+++ b/common/changes/@itwin/node-cli-authorization/better-token-store-key_2022-04-27-15-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/node-cli-authorization",
+      "comment": "Include issuerUrl in TokenStore key to avoid conflicts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/node-cli-authorization"
+}

--- a/packages/node-cli/package.json
+++ b/packages/node-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/node-cli-authorization",
-  "version": "0.9.1",
+  "version": "0.9.0",
   "main": "lib/cjs/Client.js",
   "types": "lib/cjs/Client.d.ts",
   "description": "Node.js command-line authorization client for iTwin platform",

--- a/packages/node-cli/package.json
+++ b/packages/node-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/node-cli-authorization",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "lib/cjs/Client.js",
   "types": "lib/cjs/Client.d.ts",
   "description": "Node.js command-line authorization client for iTwin platform",

--- a/packages/node-cli/src/Client.ts
+++ b/packages/node-cli/src/Client.ts
@@ -76,7 +76,7 @@ export class NodeCliAuthorizationClient implements AuthorizationClient {
   public constructor(config: NodeCliAuthorizationConfiguration) {
     this._bakedConfig = new BakedAuthorizationConfiguration(config);
 
-    const appStorageKey = `Bentley.iTwinJs.OidcTokenStore.${this._bakedConfig.clientId}`;
+    const appStorageKey = `iTwinJs:${this._bakedConfig.clientId}:${this._bakedConfig.issuerUrl}`;
     this._tokenStore = new TokenStore(appStorageKey);
   }
 


### PR DESCRIPTION
Incorporate issuerUrl into TokenStore key to avoid conflicts between credentials that share a clientId but were generated from different issuing authorities. This is a common problem for Bentley when testing between QA and PROD.

Also shortened the "iTwinJs" boilerplate to make the entries more readable in Credential Manager, etc.