### PR TITLE
Incorporate scopes into caching key for credentials

### DIFF
--- a/packages/node-cli/src/Client.ts
+++ b/packages/node-cli/src/Client.ts
@@ -5,6 +5,7 @@
 // Code based on the blog article @ https://authguidance.com
 
 import * as Http from "http";
+import * as crypto from "crypto";
 import * as open from "open";
 import { assert, AuthStatus, BeEvent, BentleyError, Logger } from "@itwin/core-bentley";
 import {
@@ -76,7 +77,7 @@ export class NodeCliAuthorizationClient implements AuthorizationClient {
   public constructor(config: NodeCliAuthorizationConfiguration) {
     this._bakedConfig = new BakedAuthorizationConfiguration(config);
 
-    const appStorageKey = `iTwinJs:${this._bakedConfig.clientId}:${this._bakedConfig.issuerUrl}`;
+    const appStorageKey = makeAppStorageKey({ ...this._bakedConfig });
     this._tokenStore = new TokenStore(appStorageKey);
   }
 
@@ -289,6 +290,16 @@ export class NodeCliAuthorizationClient implements AuthorizationClient {
     const httpServer = Http.createServer(onBrowserRequest);
     httpServer.listen(new URL(redirectUrl).port);
   }
+}
+
+/**
+ * @internal
+ */
+export function makeAppStorageKey(namedArgs: {clientId: string, issuerUrl: string, scopes: string}): string {
+  // A stored credential is only valid for a combination of the clientId, the issuing authority and the requested scopes.
+  // Incorporate all these parameters into the secure storage key in order to avoid reusing mismatched credentials.
+  const scopesHash = crypto.createHash("md5").update(namedArgs.scopes).digest("hex");
+  return `iTwinJs:${namedArgs.clientId}:${namedArgs.issuerUrl}:${scopesHash}`;
 }
 
 /**

--- a/packages/node-cli/src/test/Client.test.ts
+++ b/packages/node-cli/src/test/Client.test.ts
@@ -6,7 +6,7 @@
 import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
 
-import { BakedAuthorizationConfiguration } from "../Client";
+import { BakedAuthorizationConfiguration, makeAppStorageKey } from "../Client";
 import type { NodeCliAuthorizationConfiguration } from "../Client";
 
 chai.use(chaiAsPromised);
@@ -56,6 +56,36 @@ describe("NodeCliAuthorizationConfiguration Authority URL Logic", () => {
     process.env.IMJS_URL_PREFIX = "dev-";
     const bakedConfig = new BakedAuthorizationConfiguration(config);
     chai.expect(bakedConfig.issuerUrl).equals("https://qa-ims.bentley.com");
+  });
+});
+
+describe("NodeCliAuthorizationConfiguration TokenStore Key Logic", () => {
+  const baselineKeyArgs = {
+    clientId: "testClientId",
+    issuerUrl: "https://test.authority.com",
+    scopes: "testScope:read testScope:modify",
+  };
+  const baselineKey = makeAppStorageKey(baselineKeyArgs);
+
+  it("should create different keys based on clientId", () => {
+    const testKeyArgs = { ...baselineKeyArgs };
+    testKeyArgs.clientId = "anotherClientId";
+    const testKey = makeAppStorageKey(testKeyArgs);
+    chai.expect(testKey).is.not.equal(baselineKey);
+  });
+
+  it("should create different keys based on issuerUrl", () => {
+    const testKeyArgs = { ...baselineKeyArgs };
+    testKeyArgs.issuerUrl = "https://test.new-authority.com";
+    const testKey = makeAppStorageKey(testKeyArgs);
+    chai.expect(testKey).is.not.equal(baselineKey);
+  });
+
+  it("should create different keys based on scopes", () => {
+    const testKeyArgs = { ...baselineKeyArgs };
+    testKeyArgs.scopes = "anotherScope:read";
+    const testKey = makeAppStorageKey(testKeyArgs);
+    chai.expect(testKey).is.not.equal(baselineKey);
   });
 });
 


### PR DESCRIPTION
Ensure we only use cached credentials that match client ID, issuing authority and scopes. Otherwise, operations will fail with opaque error messages.

I encountered this doing test development of my own, but I'm guessing this is the underlying issue here: https://github.com/iTwin/itwinjs-core/discussions/3483#discussioncomment-2774943

We should do the same for Electron @evelynpreslar-bentley 