### PR TITLE
Upgraded jsonwebtoken

### DIFF
--- a/common/changes/@itwin/browser-authorization/mindaugas-upgrade-jsonwebtoken_2022-12-23-13-41.json
+++ b/common/changes/@itwin/browser-authorization/mindaugas-upgrade-jsonwebtoken_2022-12-23-13-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/browser-authorization",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/browser-authorization"
+}

--- a/common/changes/@itwin/electron-authorization/mindaugas-upgrade-jsonwebtoken_2022-12-23-13-41.json
+++ b/common/changes/@itwin/electron-authorization/mindaugas-upgrade-jsonwebtoken_2022-12-23-13-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/electron-authorization",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/electron-authorization"
+}

--- a/common/changes/@itwin/oidc-signin-tool/mindaugas-upgrade-jsonwebtoken_2022-12-23-13-41.json
+++ b/common/changes/@itwin/oidc-signin-tool/mindaugas-upgrade-jsonwebtoken_2022-12-23-13-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/oidc-signin-tool",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/oidc-signin-tool"
+}

--- a/common/changes/@itwin/service-authorization/mindaugas-upgrade-jsonwebtoken_2022-12-23-13-41.json
+++ b/common/changes/@itwin/service-authorization/mindaugas-upgrade-jsonwebtoken_2022-12-23-13-41.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@itwin/service-authorization",
       "comment": "Upgraded jsonwebtoken dependency",
-      "type": "minor"
+      "type": "patch"
     }
   ],
   "packageName": "@itwin/service-authorization"

--- a/common/changes/@itwin/service-authorization/mindaugas-upgrade-jsonwebtoken_2022-12-23-13-41.json
+++ b/common/changes/@itwin/service-authorization/mindaugas-upgrade-jsonwebtoken_2022-12-23-13-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/service-authorization",
+      "comment": "Upgraded jsonwebtoken dependency",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/service-authorization"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -14,14 +14,14 @@ importers:
       '@types/chai': ^4.2.22
       '@types/mocha': ^8.2.3
       '@types/node': 14.14.31
-      '@types/sinon': ^9.0.0
+      '@types/sinon': ^10.0.13
       chai: ^4.2.22
       eslint: ^7.32.0
       mocha: ^8.2.3
       nyc: ^15.1.0
       oidc-client: ^1.11.5
       rimraf: ^3.0.2
-      sinon: ^9.0.0
+      sinon: ^15.0.1
       typescript: ~4.3.5
     dependencies:
       oidc-client: 1.11.5
@@ -33,13 +33,13 @@ importers:
       '@types/chai': 4.2.22
       '@types/mocha': 8.2.3
       '@types/node': 14.14.31
-      '@types/sinon': 9.0.11
+      '@types/sinon': 10.0.13
       chai: 4.3.4
       eslint: 7.32.0
       mocha: 8.4.0
       nyc: 15.1.0
       rimraf: 3.0.2
-      sinon: 9.2.4
+      sinon: 15.0.1
       typescript: 4.3.5
 
   ../../packages/electron:
@@ -52,7 +52,7 @@ importers:
       '@types/chai': ^4.2.22
       '@types/chai-as-promised': ^7
       '@types/mocha': ^8.2.3
-      '@types/sinon': ^9.0.0
+      '@types/sinon': ^10.0.13
       chai: ^4.2.22
       chai-as-promised: ^7
       electron: ^22.0.0
@@ -62,7 +62,7 @@ importers:
       nyc: ^15.1.0
       open: ^8.3.0
       rimraf: ^3.0.2
-      sinon: ^9.0.0
+      sinon: ^15.0.1
       source-map-support: ^0.5.9
       typescript: ~4.3.5
       username: ^5.1.0
@@ -79,7 +79,7 @@ importers:
       '@types/chai': 4.2.22
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 8.2.3
-      '@types/sinon': 9.0.11
+      '@types/sinon': 10.0.13
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       electron: 22.0.0
@@ -87,7 +87,7 @@ importers:
       mocha: 8.4.0
       nyc: 15.1.0
       rimraf: 3.0.2
-      sinon: 9.2.4
+      sinon: 15.0.1
       source-map-support: 0.5.21
       typescript: 4.3.5
 
@@ -147,7 +147,7 @@ importers:
       '@types/chai-as-promised': ^7
       '@types/mocha': ^8.2.3
       '@types/node': 14.14.31
-      '@types/sinon': ^7.5.1
+      '@types/sinon': ^10.0.13
       chai: ^4.2.22
       chai-as-promised: ^7
       dotenv: ^10.0.0
@@ -158,7 +158,7 @@ importers:
       openid-client: ^4.7.4
       puppeteer: ^13.5.2
       rimraf: ^3.0.2
-      sinon: ^7.5.0
+      sinon: ^15.0.1
       typescript: ~4.3.5
     dependencies:
       '@itwin/certa': 3.0.0
@@ -175,14 +175,14 @@ importers:
       '@types/chai-as-promised': 7.1.4
       '@types/mocha': 8.2.3
       '@types/node': 14.14.31
-      '@types/sinon': 7.5.2
+      '@types/sinon': 10.0.13
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       eslint: 7.32.0
       mocha: 8.4.0
       nyc: 15.1.0
       rimraf: 3.0.2
-      sinon: 7.5.0
+      sinon: 15.0.1
       typescript: 4.3.5
 
   ../../packages/service:
@@ -193,23 +193,23 @@ importers:
       '@itwin/eslint-plugin': ^3.0.0
       '@types/chai': ^4.2.22
       '@types/chai-as-promised': ^7
-      '@types/jsonwebtoken': ^8.5.5
+      '@types/jsonwebtoken': ^8.5.9
       '@types/mocha': ^8.2.3
-      '@types/sinon': ^9.0.0
+      '@types/sinon': ^10.0.13
       chai: ^4.2.22
       chai-as-promised: ^7
       eslint: ^7.32.0
-      jsonwebtoken: ^8.5.1
+      jsonwebtoken: ^9.0.0
       jwks-rsa: ^2.0.4
       mocha: ^8.2.3
       nyc: ^15.1.0
       openid-client: ^4.7.4
       rimraf: ^3.0.2
-      sinon: ^9.0.0
+      sinon: ^15.0.1
       source-map-support: ^0.5.9
       typescript: ~4.3.5
     dependencies:
-      jsonwebtoken: 8.5.1
+      jsonwebtoken: 9.0.0
       jwks-rsa: 2.0.5
       openid-client: 4.9.1
     devDependencies:
@@ -219,16 +219,16 @@ importers:
       '@itwin/eslint-plugin': 3.0.0_eslint@7.32.0+typescript@4.3.5
       '@types/chai': 4.2.22
       '@types/chai-as-promised': 7.1.4
-      '@types/jsonwebtoken': 8.5.6
+      '@types/jsonwebtoken': 8.5.9
       '@types/mocha': 8.2.3
-      '@types/sinon': 9.0.11
+      '@types/sinon': 10.0.13
       chai: 4.3.4
       chai-as-promised: 7.1.1_chai@4.3.4
       eslint: 7.32.0
       mocha: 8.4.0
       nyc: 15.1.0
       rimraf: 3.0.2
-      sinon: 9.2.4
+      sinon: 15.0.1
       source-map-support: 0.5.21
       typescript: 4.3.5
 
@@ -722,37 +722,22 @@ packages:
     resolution: {integrity: sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw==}
     engines: {node: '>=10'}
 
-  /@sinonjs/commons/1.8.3:
-    resolution: {integrity: sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==}
+  /@sinonjs/commons/2.0.0:
+    resolution: {integrity: sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==}
     dependencies:
       type-detect: 4.0.8
     dev: true
 
-  /@sinonjs/fake-timers/6.0.1:
-    resolution: {integrity: sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==}
+  /@sinonjs/fake-timers/10.0.2:
+    resolution: {integrity: sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==}
     dependencies:
-      '@sinonjs/commons': 1.8.3
+      '@sinonjs/commons': 2.0.0
     dev: true
 
-  /@sinonjs/formatio/3.2.2:
-    resolution: {integrity: sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==}
+  /@sinonjs/samsam/7.0.1:
+    resolution: {integrity: sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==}
     dependencies:
-      '@sinonjs/commons': 1.8.3
-      '@sinonjs/samsam': 3.3.3
-    dev: true
-
-  /@sinonjs/samsam/3.3.3:
-    resolution: {integrity: sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==}
-    dependencies:
-      '@sinonjs/commons': 1.8.3
-      array-from: 2.1.1
-      lodash: 4.17.21
-    dev: true
-
-  /@sinonjs/samsam/5.3.1:
-    resolution: {integrity: sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==}
-    dependencies:
-      '@sinonjs/commons': 1.8.3
+      '@sinonjs/commons': 2.0.0
       lodash.get: 4.4.2
       type-detect: 4.0.8
     dev: true
@@ -853,10 +838,10 @@ packages:
     resolution: {integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=}
     dev: true
 
-  /@types/jsonwebtoken/8.5.6:
-    resolution: {integrity: sha512-+P3O/xC7nzVizIi5VbF34YtqSonFsdnbXBnWUCYRiKOi1f9gA4sEFvXkrGr/QVV23IbMYvcoerI7nnhDUiWXRQ==}
+  /@types/jsonwebtoken/8.5.9:
+    resolution: {integrity: sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==}
     dependencies:
-      '@types/node': 14.14.31
+      '@types/node': 16.18.3
     dev: true
 
   /@types/keyv/3.1.3:
@@ -906,12 +891,8 @@ packages:
       '@types/node': 14.14.31
     dev: false
 
-  /@types/sinon/7.5.2:
-    resolution: {integrity: sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==}
-    dev: true
-
-  /@types/sinon/9.0.11:
-    resolution: {integrity: sha512-PwP4UY33SeeVKodNE37ZlOsR9cReypbMJOhZ7BVE0lB+Hix3efCOxiJWiE5Ia+yL9Cn2Ch72EjFTRze8RZsNtg==}
+  /@types/sinon/10.0.13:
+    resolution: {integrity: sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==}
     dependencies:
       '@types/sinonjs__fake-timers': 8.1.0
     dev: true
@@ -1238,10 +1219,6 @@ packages:
     resolution: {integrity: sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=}
     dev: false
 
-  /array-from/2.1.1:
-    resolution: {integrity: sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==}
-    dev: true
-
   /array-includes/3.1.4:
     resolution: {integrity: sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==}
     engines: {node: '>= 0.4'}
@@ -1373,7 +1350,7 @@ packages:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   /buffer-equal-constant-time/1.0.1:
-    resolution: {integrity: sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=}
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
     dev: false
 
   /buffer-from/1.1.2:
@@ -1848,16 +1825,6 @@ packages:
   /devtools-protocol/0.0.969999:
     resolution: {integrity: sha512-6GfzuDWU0OFAuOvBokXpXPLxjOJ5DZ157Ue3sGQQM3LgAamb8m0R0ruSfN0DDu+XG5XJgT50i6zZ/0o8RglreQ==}
     dev: false
-
-  /diff/3.5.0:
-    resolution: {integrity: sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==}
-    engines: {node: '>=0.3.1'}
-    dev: true
-
-  /diff/4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
-    engines: {node: '>=0.3.1'}
-    dev: true
 
   /diff/5.0.0:
     resolution: {integrity: sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==}
@@ -3280,20 +3247,14 @@ packages:
       graceful-fs: 4.2.8
     dev: true
 
-  /jsonwebtoken/8.5.1:
-    resolution: {integrity: sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==}
-    engines: {node: '>=4', npm: '>=1.4.28'}
+  /jsonwebtoken/9.0.0:
+    resolution: {integrity: sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==}
+    engines: {node: '>=12', npm: '>=6'}
     dependencies:
       jws: 3.2.2
-      lodash.includes: 4.3.0
-      lodash.isboolean: 3.0.3
-      lodash.isinteger: 4.0.4
-      lodash.isnumber: 3.0.3
-      lodash.isplainobject: 4.0.6
-      lodash.isstring: 4.0.1
-      lodash.once: 4.1.1
+      lodash: 4.17.21
       ms: 2.1.3
-      semver: 5.7.1
+      semver: 7.3.8
     dev: false
 
   /jsx-ast-utils/3.2.1:
@@ -3410,44 +3371,16 @@ packages:
     dev: true
 
   /lodash.get/4.4.2:
-    resolution: {integrity: sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=}
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     dev: true
-
-  /lodash.includes/4.3.0:
-    resolution: {integrity: sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=}
-    dev: false
-
-  /lodash.isboolean/3.0.3:
-    resolution: {integrity: sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=}
-    dev: false
 
   /lodash.isequal/4.5.0:
     resolution: {integrity: sha1-QVxEePK8wwEgwizhDtMib30+GOA=}
     dev: true
 
-  /lodash.isinteger/4.0.4:
-    resolution: {integrity: sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=}
-    dev: false
-
-  /lodash.isnumber/3.0.3:
-    resolution: {integrity: sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=}
-    dev: false
-
-  /lodash.isplainobject/4.0.6:
-    resolution: {integrity: sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=}
-    dev: false
-
-  /lodash.isstring/4.0.1:
-    resolution: {integrity: sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=}
-    dev: false
-
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
-
-  /lodash.once/4.1.1:
-    resolution: {integrity: sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=}
-    dev: false
 
   /lodash.truncate/4.4.2:
     resolution: {integrity: sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=}
@@ -3461,16 +3394,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       chalk: 4.1.2
-
-  /lolex/4.2.0:
-    resolution: {integrity: sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==}
-    dev: true
-
-  /lolex/5.1.2:
-    resolution: {integrity: sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==}
-    dependencies:
-      '@sinonjs/commons': 1.8.3
-    dev: true
 
   /loose-envify/1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -3718,21 +3641,11 @@ packages:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: false
 
-  /nise/1.5.3:
-    resolution: {integrity: sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==}
+  /nise/5.1.4:
+    resolution: {integrity: sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==}
     dependencies:
-      '@sinonjs/formatio': 3.2.2
-      '@sinonjs/text-encoding': 0.7.1
-      just-extend: 4.2.1
-      lolex: 5.1.2
-      path-to-regexp: 1.8.0
-    dev: true
-
-  /nise/4.1.0:
-    resolution: {integrity: sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==}
-    dependencies:
-      '@sinonjs/commons': 1.8.3
-      '@sinonjs/fake-timers': 6.0.1
+      '@sinonjs/commons': 2.0.0
+      '@sinonjs/fake-timers': 10.0.2
       '@sinonjs/text-encoding': 0.7.1
       just-extend: 4.2.1
       path-to-regexp: 1.8.0
@@ -4267,7 +4180,7 @@ packages:
   /puppeteer/5.3.1:
     resolution: {integrity: sha512-YTM1RaBeYrj6n7IlRXRYLqJHF+GM7tasbvrNFx6w1S16G76NrPq7oYFKLDO+BQsXNtS8kW2GxWCXjIMPvfDyaQ==}
     engines: {node: '>=10.18.1'}
-    deprecated: Version no longer supported. Upgrade to @latest
+    deprecated: < 18.1.0 is no longer supported
     requiresBuild: true
     dependencies:
       debug: 4.3.4
@@ -4540,6 +4453,14 @@ packages:
     dependencies:
       lru-cache: 6.0.0
 
+  /semver/7.3.8:
+    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: false
+
   /send/0.17.1:
     resolution: {integrity: sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==}
     engines: {node: '>= 0.8.0'}
@@ -4654,26 +4575,14 @@ packages:
       simple-concat: 1.0.1
     dev: false
 
-  /sinon/7.5.0:
-    resolution: {integrity: sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==}
+  /sinon/15.0.1:
+    resolution: {integrity: sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==}
     dependencies:
-      '@sinonjs/commons': 1.8.3
-      '@sinonjs/formatio': 3.2.2
-      '@sinonjs/samsam': 3.3.3
-      diff: 3.5.0
-      lolex: 4.2.0
-      nise: 1.5.3
-      supports-color: 5.5.0
-    dev: true
-
-  /sinon/9.2.4:
-    resolution: {integrity: sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==}
-    dependencies:
-      '@sinonjs/commons': 1.8.3
-      '@sinonjs/fake-timers': 6.0.1
-      '@sinonjs/samsam': 5.3.1
-      diff: 4.0.2
-      nise: 4.1.0
+      '@sinonjs/commons': 2.0.0
+      '@sinonjs/fake-timers': 10.0.2
+      '@sinonjs/samsam': 7.0.1
+      diff: 5.0.0
+      nise: 5.1.4
       supports-color: 7.2.0
     dev: true
 

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -37,11 +37,11 @@
     "@types/chai": "^4.2.22",
     "@types/mocha": "^8.2.3",
     "@types/node": "14.14.31",
-    "@types/sinon": "^9.0.0",
+    "@types/sinon": "^10.0.13",
     "chai": "^4.2.22",
     "mocha": "^8.2.3",
     "nyc": "^15.1.0",
-    "sinon": "^9.0.0",
+    "sinon": "^15.0.1",
     "eslint": "^7.32.0",
     "rimraf": "^3.0.2",
     "typescript": "~4.3.5"

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -36,7 +36,7 @@
     "@types/chai": "^4.2.22",
     "@types/chai-as-promised": "^7",
     "@types/mocha": "^8.2.3",
-    "@types/sinon": "^9.0.0",
+    "@types/sinon": "^10.0.13",
     "chai": "^4.2.22",
     "chai-as-promised": "^7",
     "electron": "^22.0.0",
@@ -45,7 +45,7 @@
     "mocha": "^8.2.3",
     "nyc": "^15.1.0",
     "rimraf": "^3.0.2",
-    "sinon": "^9.0.0",
+    "sinon": "^15.0.1",
     "typescript": "~4.3.5"
   },
   "peerDependencies": {

--- a/packages/oidc-signin-tool/package.json
+++ b/packages/oidc-signin-tool/package.json
@@ -47,14 +47,14 @@
     "@types/chai-as-promised": "^7",
     "@types/mocha": "^8.2.3",
     "@types/node": "14.14.31",
-    "@types/sinon": "^7.5.1",
+    "@types/sinon": "^10.0.13",
     "chai": "^4.2.22",
     "chai-as-promised": "^7",
     "eslint": "^7.32.0",
     "mocha": "^8.2.3",
     "nyc": "^15.1.0",
     "rimraf": "^3.0.2",
-    "sinon": "^7.5.0",
+    "sinon": "^15.0.1",
     "typescript": "~4.3.5"
   },
   "peerDependencies": {

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/iTwin/auth-clients"
   },
   "dependencies": {
-    "jsonwebtoken": "^8.5.1",
+    "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^2.0.4",
     "openid-client": "^4.7.4"
   },
@@ -36,16 +36,16 @@
     "@itwin/eslint-plugin": "^3.0.0",
     "@types/chai": "^4.2.22",
     "@types/chai-as-promised": "^7",
-    "@types/jsonwebtoken": "^8.5.5",
+    "@types/jsonwebtoken": "^8.5.9",
     "@types/mocha": "^8.2.3",
-    "@types/sinon": "^9.0.0",
+    "@types/sinon": "^10.0.13",
     "eslint": "^7.32.0",
     "chai": "^4.2.22",
     "chai-as-promised": "^7",
     "mocha": "^8.2.3",
     "nyc": "^15.1.0",
     "rimraf": "^3.0.2",
-    "sinon": "^9.0.0",
+    "sinon": "^15.0.1",
     "source-map-support": "^0.5.9",
     "typescript": "~4.3.5"
   },

--- a/packages/service/src/test/Introspection.test.ts
+++ b/packages/service/src/test/Introspection.test.ts
@@ -53,13 +53,11 @@ describe("IntrospectionClient", () => {
   it("should throw if issuer does not support JWKS", async () => {
     sinon.stub(Issuer, "discover").resolves({ metadata: {} } as Issuer<OpenIdClient>);
     const logStub = sinon.stub(Logger, "logError");
-    sinon.stub(jwt, "decode").returns({
-      header: {},
-      payload: { scope: ["scope1", "scope2"] },
-    });
+
+    const token = jwt.sign({ scope: ["scope1", "scope2"] }, "very secret");
 
     const client = new IntrospectionClient();
-    await expect(client.introspect("fake token")).to.be.rejectedWith("Issuer does not support JWKS");
+    await expect(client.introspect(`fake ${token}`)).to.be.rejectedWith("Issuer does not support JWKS");
 
     expect(logStub.callCount).to.be.equal(2);
     expect(logStub.firstCall.args[1]).to.equal("Issuer does not support JWKS");
@@ -78,16 +76,15 @@ describe("IntrospectionClient", () => {
       },
     } as Issuer<OpenIdClient>);
     const logStub = sinon.stub(Logger, "logError");
-    sinon.stub(jwt, "decode").returns({
-      header: {},
-    });
     sinon.stub(jwks.JwksClient.prototype, "getSigningKey").resolves({
       getPublicKey: () => "fake key",
     });
     sinon.stub(jwt, "verify");
 
+    const token = jwt.sign({}, "very secret");
+
     const client = new IntrospectionClient();
-    await expect(client.introspect("fake token")).to.be.rejectedWith("Missing scope in JWT");
+    await expect(client.introspect(`fake ${token}`)).to.be.rejectedWith("Missing scope in JWT");
 
     expect(logStub.callCount).to.equal(1);
     expect(logStub.firstCall.args[1]).to.equal("Unable to introspect client token");
@@ -101,17 +98,15 @@ describe("IntrospectionClient", () => {
       },
     } as Issuer<OpenIdClient>);
     const logStub = sinon.stub(Logger, "logError");
-    sinon.stub(jwt, "decode").returns({
-      header: {},
-      payload: { scope: [1, 2, 3] },
-    });
     sinon.stub(jwks.JwksClient.prototype, "getSigningKey").resolves({
       getPublicKey: () => "fake key",
     });
     sinon.stub(jwt, "verify");
 
+    const token = jwt.sign({ scope: [1, 2, 3] }, "very secret");
+
     const client = new IntrospectionClient();
-    await expect(client.introspect("fake token")).to.be.rejectedWith("Invalid scope");
+    await expect(client.introspect(`fake ${token}`)).to.be.rejectedWith("Invalid scope");
 
     expect(logStub.callCount).to.equal(1);
     expect(logStub.firstCall.args[1]).to.equal("Unable to introspect client token");
@@ -127,11 +122,6 @@ describe("IntrospectionClient", () => {
     const fakeKey1 = { getPublicKey: () => "fake key1" };
     const fakeKey2 = { getPublicKey: () => "fake key2" };
     const payload = { scope: ["scope1", "scope2"] };
-    sinon.stub(jwt, "decode")
-      .onFirstCall().returns({ payload, header: { kid: "kid1" } })
-      .onSecondCall().returns({ payload, header: { kid: "kid2" } })
-      .onThirdCall().returns({ payload, header: { kid: "kid2" } })
-      .returns({ payload, header: {} });
 
     const keyStub = sinon.stub(jwks.JwksClient.prototype, "getSigningKey").callsFake(async (kid) => {
       if (kid === "kid1") return fakeKey1;
@@ -142,10 +132,16 @@ describe("IntrospectionClient", () => {
 
     sinon.stub(jwt, "verify");
 
+    const token1 = jwt.sign(payload, "very secret", { header: { kid: "kid1", alg: "none" } });
+    const token2 = jwt.sign(payload, "very secret", { header: { kid: "kid2", alg: "none" } });
+    const token3 = jwt.sign(payload, "very secret", { header: { kid: "kid2", alg: "none" } });
+    const token4 = jwt.sign(payload, "very secret");
+    const token5 = jwt.sign(payload, "very secret");
+
     const client = new IntrospectionClient();
 
     // call with kid1 - added to cache
-    await client.introspect("fake token1");
+    await client.introspect(`fake ${token1}`);
     expect(client["_signingKeyCache"].size).to.equal(1);
     expect(client["_signingKeyCache"].has("kid1")).to.be.true;
     expect(client["_signingKeyCache"].get("kid1")).to.equal(fakeKey1);
@@ -156,7 +152,7 @@ describe("IntrospectionClient", () => {
     client["_jwks"]!.getSigningKey = jwks.JwksClient.prototype.getSigningKey.bind(client["_jwks"]);
 
     // call with kid2 - added to cache
-    await client.introspect("fake token2");
+    await client.introspect(`fake ${token2}`);
     expect(client["_signingKeyCache"].size).to.equal(2);
     expect(client["_signingKeyCache"].has("kid2")).to.be.true;
     expect(client["_signingKeyCache"].get("kid2")).to.equal(fakeKey2);
@@ -164,18 +160,18 @@ describe("IntrospectionClient", () => {
     expect(keyStub.lastCall.firstArg).to.equal("kid2");
 
     // call with kid2 - already in cache, nothing changes
-    await client.introspect("fake token3");
+    await client.introspect(`fake ${token3}`);
     expect(client["_signingKeyCache"].size).to.equal(2);
     expect(keyStub.callCount).to.equal(2);
 
     // call without kid - new key retrieved, cache not affected
-    await client.introspect("fake token4");
+    await client.introspect(`fake ${token4}`);
     expect(client["_signingKeyCache"].size).to.equal(2);
     expect(keyStub.callCount).to.equal(3);
     expect(keyStub.lastCall.firstArg).to.be.undefined;
 
     // call without kid - new key retrieved, cache not affected
-    await client.introspect("fake token5");
+    await client.introspect(`fake ${token5}`);
     expect(client["_signingKeyCache"].size).to.equal(2);
     expect(keyStub.callCount).to.equal(4);
     expect(keyStub.lastCall.firstArg).to.be.undefined;


### PR DESCRIPTION
`jsonwebtoken` (<= 8.5.1) has insecure input validation in jwt.verify function - https://github.com/advisories/GHSA-27h2-hvpr-p74q .

Upgraded `jsonwebtoken` to 9.0.0.
Also upgraded `sinon` and changed the tests a bit, because it is no longer possible to mock `decode`.

Fixes #94
