### PR TITLE
Start supporting Electron 23, drop older Electron versions

### DIFF
--- a/common/changes/@itwin/electron-authorization/gytis-change-Electron-support-range_2023-02-09-10-56.json
+++ b/common/changes/@itwin/electron-authorization/gytis-change-Electron-support-range_2023-02-09-10-56.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@itwin/electron-authorization",
       "comment": "Drop support for Electron 14, 15, 16, 17, 22. Start supporting Electron 23.",
-      "type": "major"
+      "type": "minor"
     }
   ],
   "packageName": "@itwin/electron-authorization"

--- a/common/changes/@itwin/electron-authorization/gytis-change-Electron-support-range_2023-02-09-10-56.json
+++ b/common/changes/@itwin/electron-authorization/gytis-change-Electron-support-range_2023-02-09-10-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/electron-authorization",
+      "comment": "Drop support for Electron 14, 15, 16, 17, 22. Start supporting Electron 23.",
+      "type": "major"
+    }
+  ],
+  "packageName": "@itwin/electron-authorization"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
       '@types/sinon': ^10.0.13
       chai: ^4.2.22
       chai-as-promised: ^7
-      electron: ^22.0.0
+      electron: ^23.0.0
       eslint: ^7.32.0
       keytar: ^7.8.0
       mocha: ^8.2.3
@@ -82,7 +82,7 @@ importers:
       '@types/sinon': 10.0.13
       chai: 4.3.7
       chai-as-promised: 7.1.1_chai@4.3.7
-      electron: 22.0.1
+      electron: 23.0.0
       eslint: 7.32.0
       mocha: 8.4.0
       nyc: 15.1.0
@@ -1953,8 +1953,8 @@ packages:
     resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
     dev: true
 
-  /electron/22.0.1:
-    resolution: {integrity: sha512-05X/UmQOtUYwFmytY4/rc+4Iz+LYzHhftRZDkx1GQzyX/BxopStddG8LMcx3SESNk25F2J93oHv1Lzs6QWeCjA==}
+  /electron/23.0.0:
+    resolution: {integrity: sha512-S6hVtTAjauMiiWP9sBVR5RpcUC464cNZ06I2EMUjeZBq+KooS6tLmNsfw0zLpAXDp1qosjlBP3v71NTZ3gd9iA==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -39,7 +39,7 @@
     "@types/sinon": "^10.0.13",
     "chai": "^4.2.22",
     "chai-as-promised": "^7",
-    "electron": "^22.0.0",
+    "electron": "^23.0.0",
     "source-map-support": "^0.5.9",
     "eslint": "^7.32.0",
     "mocha": "^8.2.3",
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "@itwin/core-bentley": "^3.3.0",
-    "electron": ">=14.0.0 <18.0.0 || >=22.0.0 <23.0.0"
+    "electron": "^23.0.0"
   },
   "eslintConfig": {
     "plugins": [


### PR DESCRIPTION
## Changes

- Dropped Electron versions:
  - Electron 14, 15, 16, 17 - reached end-of-life.
  - Electron 22 - uses Node 16, which we want to drop.
- Added support for Electron 23. No changes are required since none of the [breaking changes](https://github.com/electron/electron/blob/main/docs/breaking-changes.md#planned-breaking-api-changes-230) should affect us.