### PR TITLE
correctly specify user redirect state

### DIFF
--- a/common/changes/@itwin/browser-authorization/bdp-fix-oidc-ts-state-redirect_2023-02-28-15-52.json
+++ b/common/changes/@itwin/browser-authorization/bdp-fix-oidc-ts-state-redirect_2023-02-28-15-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/browser-authorization",
+      "comment": "fix broken final redirect",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/browser-authorization"
+}

--- a/packages/browser/src/Client.ts
+++ b/packages/browser/src/Client.ts
@@ -192,7 +192,7 @@ export class BrowserAuthorizationClient implements AuthorizationClient {
     };
 
     const redirectArgs = { ...state, ...args };
-    await userManager.signinRedirect(redirectArgs); // This call changes the window's URL, which effectively ends execution here unless an exception is thrown.
+    await userManager.signinRedirect({state: redirectArgs}); // This call changes the window's URL, which effectively ends execution here unless an exception is thrown.
   }
 
   /**


### PR DESCRIPTION
Missed in the upgrade to `oidc-client-ts` - user-defined state must be passed as a state property to `signinRedirect` rather than as the first argument itself.