### PR TITLE
Readdress insufficient fix for browser auth state

### DIFF
--- a/common/changes/@itwin/browser-authorization/evelyn.preslar-fix-browser-auth-state_2023-02-28-17-25.json
+++ b/common/changes/@itwin/browser-authorization/evelyn.preslar-fix-browser-auth-state_2023-02-28-17-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/browser-authorization",
+      "comment": "fix the fix for passing browser auth redirect state",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/browser-authorization"
+}

--- a/packages/browser/src/Client.ts
+++ b/packages/browser/src/Client.ts
@@ -191,8 +191,8 @@ export class BrowserAuthorizationClient implements AuthorizationClient {
       successRedirectUrl: successRedirectUrl || window.location.href,
     };
 
-    const redirectArgs = { ...state, ...args };
-    await userManager.signinRedirect({state: redirectArgs}); // This call changes the window's URL, which effectively ends execution here unless an exception is thrown.
+    const redirectArgs = { state, ...args };
+    await userManager.signinRedirect(redirectArgs); // This call changes the window's URL, which effectively ends execution here unless an exception is thrown.
   }
 
   /**


### PR DESCRIPTION
Quick reaction to https://github.com/iTwin/auth-clients/pull/115

Revert to original behavior before the `oidc-client-ts` PR, [which incorrectly added a spread operator to `state`](https://github.com/iTwin/auth-clients/pull/88/files#diff-b0a661305ee18a0bbbf555ea6657e2f6fb990a4057c1abc395301f41ce2ad509L189).