### PR TITLE
Add support for Electron 24

### DIFF
--- a/common/changes/@itwin/electron-authorization/gytis-Electron-24-support_2023-04-12-14-49.json
+++ b/common/changes/@itwin/electron-authorization/gytis-Electron-24-support_2023-04-12-14-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/electron-authorization",
+      "comment": "Add support for Electron 24.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/electron-authorization"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
       '@types/sinon': ^10.0.13
       chai: ^4.2.22
       chai-as-promised: ^7
-      electron: ^23.0.0
+      electron: ^24.0.0
       eslint: ^7.32.0
       keytar: ^7.8.0
       mocha: ^8.2.3
@@ -92,7 +92,7 @@ importers:
       '@types/sinon': 10.0.13
       chai: 4.3.7
       chai-as-promised: 7.1.1_chai@4.3.7
-      electron: 23.1.3
+      electron: 24.1.0
       eslint: 7.32.0
       mocha: 8.4.0
       nyc: 15.1.0
@@ -2900,14 +2900,14 @@ packages:
     resolution: {integrity: sha512-DE9tTy2PNmy1v55AZAO542ui+MLC2cvINMK4P2LXGsJdput/ThVG9t+QGecPuAZZSgC8XoI+Jh9M1OG9IoNSCw==}
     dev: true
 
-  /electron/23.1.3:
-    resolution: {integrity: sha512-MNjuUS2K6/OxlJ0zTC77djo1R3xM038v1kUunvNFgDMZHYKpSOzOMNsPiwM2BGp+uZbkUb0nTnYafxXrM8H16w==}
+  /electron/24.1.0:
+    resolution: {integrity: sha512-XIAcxBBKIM3S8oYrYmyoXb39CJDpwxrPsSQJmCIzGGNhbKigtRxwlB/TfVCVAyHFsvXQKZKPZ+m0qpqDnDDwCA==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true
     dependencies:
       '@electron/get': 2.0.2
-      '@types/node': 16.18.14
+      '@types/node': 18.15.0
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^16.0.0",
     "chai": "^4.2.22",
     "chai-as-promised": "^7",
-    "electron": "^23.0.0",
+    "electron": "^24.0.0",
     "source-map-support": "^0.5.9",
     "eslint": "^7.32.0",
     "mocha": "^8.2.3",
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "@itwin/core-bentley": "^3.3.0",
-    "electron": "^23.0.0"
+    "electron": ">=23.0.0 <25.0.0"
   },
   "eslintConfig": {
     "plugins": [


### PR DESCRIPTION
## Changes
- Extend supported Electron versions with Electron 24.
- Increase Electron dev dependency version to `^24.0.0`.

No code changes are required since we don't use [changed API](https://github.com/electron/electron/blob/main/docs/breaking-changes.md#planned-breaking-api-changes-240).