### PR TITLE
add static method for configless sign in callback

### DIFF
--- a/common/changes/@itwin/browser-authorization/bdp-configless-callback_2023-04-13-14-43.json
+++ b/common/changes/@itwin/browser-authorization/bdp-configless-callback_2023-04-13-14-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/browser-authorization",
+      "comment": "Add static BrowserAuthorizationClient.handleSigninCallback method for configless callback",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@itwin/browser-authorization"
+}

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -49,6 +49,11 @@ If the callback occurs on a page where the configured `client` is not available,
 
 ```typescript
 await BrowserAuthorizationClient.handleSigninCallback()
+
+// This library defaults to localStorage for storing state.
+// To use sessionStorage (or another Storage object), you can pass it as an argument.
+// If overriding the default localStorage, also set the stateStore via client.setAdvancedSettings({stateStore: yourStore})
+await BrowserAuthorizationClient.handleSigninCallback(window.sessionStorage)
 ```
 
 This will pull the client configuration from localStorage, using the state nonce provided by OIDC to select the proper configuration.
@@ -56,6 +61,7 @@ This will pull the client configuration from localStorage, using the state nonce
 Other notable methods:
 `client.signOutRedirect()` - starts the signout flow via redirect
 `client.signOutPopup()` - starts the signout flow via popup.
+`client.setAdvancedSettings(userManagerSettings)` - Allows for advanced options to be supplied to the underlying UserManager.
 
 ## Authorization Overview
 

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -45,6 +45,14 @@ await client.handleSigninCallback();
 
 to complete the process. Once back on your initial page, the call to `client.signInSilent` will succeed and you should be authorized.
 
+If the callback occurs on a page where the configured `client` is not available, you can use the static method to complete the process:
+
+```typescript
+await BrowserAuthorizationClient.handleSigninCallback()
+```
+
+This will pull the client configuration from localStorage, using the state nonce provided by OIDC to select the proper configuration.
+
 Other notable methods:
 `client.signOutRedirect()` - starts the signout flow via redirect
 `client.signOutPopup()` - starts the signout flow via popup.

--- a/packages/browser/playwright.config.ts
+++ b/packages/browser/playwright.config.ts
@@ -17,5 +17,6 @@ export default defineConfig({
   },
   use: {
     screenshot: "only-on-failure",
+    headless: true,
   },
 });

--- a/packages/browser/src/Client.ts
+++ b/packages/browser/src/Client.ts
@@ -424,9 +424,9 @@ export class BrowserAuthorizationClient implements AuthorizationClient {
    * from localStorage.
    */
   public static async handleSignInCallback() {
-    const StaticClient = new BrowserAuthorizationClient({} as any);
-    this.tryLoadSettingsFromStorage(StaticClient);
-    await StaticClient.handleSigninCallback();
+    const staticClient = new BrowserAuthorizationClient({} as any);
+    this.tryLoadSettingsFromStorage(staticClient);
+    await staticClient.handleSigninCallback();
   }
 
   private static tryLoadSettingsFromStorage(

--- a/packages/browser/src/Client.ts
+++ b/packages/browser/src/Client.ts
@@ -425,11 +425,11 @@ export class BrowserAuthorizationClient implements AuthorizationClient {
    */
   public static async handleSignInCallback() {
     const staticClient = new BrowserAuthorizationClient({} as any);
-    this.tryLoadSettingsFromStorage(staticClient);
+    this.loadSettingsFromStorage(staticClient);
     await staticClient.handleSigninCallback();
   }
 
-  private static tryLoadSettingsFromStorage(
+  private static loadSettingsFromStorage(
     client: BrowserAuthorizationClient
   ) {
     const url = new URL(window.location.href);

--- a/packages/browser/src/Client.ts
+++ b/packages/browser/src/Client.ts
@@ -422,7 +422,7 @@ export class BrowserAuthorizationClient implements AuthorizationClient {
    * Configuration-less sign in callback. Useful for when a client instance with configuration is not present
    * on the page or route where the callback is needed to finish the authentication process. Pulls configuration
    * from localStorage.
-   * 
+   *
    * @param store - A Storage object such as sessionStorage which stores configuration. Defaults to localStorage
    * which is also the default stateStore for this library. These stores should match.
    */

--- a/packages/browser/src/Client.ts
+++ b/packages/browser/src/Client.ts
@@ -422,20 +422,24 @@ export class BrowserAuthorizationClient implements AuthorizationClient {
    * Configuration-less sign in callback. Useful for when a client instance with configuration is not present
    * on the page or route where the callback is needed to finish the authentication process. Pulls configuration
    * from localStorage.
+   * 
+   * @param store - A Storage object such as sessionStorage which stores configuration. Defaults to localStorage
+   * which is also the default stateStore for this library. These stores should match.
    */
-  public static async handleSignInCallback() {
+  public static async handleSignInCallback(store: Storage = window.localStorage) {
     const staticClient = new BrowserAuthorizationClient({} as any);
-    this.loadSettingsFromStorage(staticClient);
+    this.loadSettingsFromStorage(staticClient, store);
     await staticClient.handleSigninCallback();
   }
 
   private static loadSettingsFromStorage(
-    client: BrowserAuthorizationClient
+    client: BrowserAuthorizationClient,
+    store: Storage
   ) {
     const url = new URL(window.location.href);
     const nonce = url.searchParams.get("state");
 
-    const storageEntry = window.localStorage.getItem(`oidc.${nonce}`);
+    const storageEntry = store.getItem(`oidc.${nonce}`);
     if (!storageEntry)
       throw new Error("Could not load oidc settings from local storage. Ensure the client is configured properly");
 

--- a/packages/browser/src/Client.ts
+++ b/packages/browser/src/Client.ts
@@ -418,6 +418,11 @@ export class BrowserAuthorizationClient implements AuthorizationClient {
     UnexpectedErrors.handle(new Error(errorMessage));
   }
 
+  /**
+   * Configuration-less sign in callback. Useful for when a client instance with configuration is not present
+   * on the page or route where the callback is needed to finish the authentication process. Pulls configuration
+   * from localStorage.
+   */
   public static async handleSignInCallback() {
     const StaticClient = new BrowserAuthorizationClient({} as any);
     this.tryLoadSettingsFromStorage(StaticClient);

--- a/packages/browser/src/integration-tests/helpers/TestHelper.ts
+++ b/packages/browser/src/integration-tests/helpers/TestHelper.ts
@@ -37,7 +37,8 @@ export class TestHelper {
 
     const user = localStorage.find((s) => s.name.startsWith("oidc.user"));
 
-    if (!user) throw new Error("Could not find user in localStorage");
+    if (!user)
+      throw new Error("Could not find user in localStorage");
 
     return User.fromStorageString(user.value);
   }
@@ -52,7 +53,8 @@ export class TestHelper {
     expect(user.access_token).toBeDefined();
 
     let url = `${this._signInOptions.url}/`;
-    if (authType === AuthType.PopUp) url += "signin-via-popup";
+    if (authType === AuthType.PopUp)
+      url += "signin-via-popup";
     if (authType === AuthType.RedirectStatic)
       url = "http://localhost:1234/?callbackFromStorage=true";
 
@@ -63,6 +65,7 @@ export class TestHelper {
     const consentAcceptButton = page.getByRole("link", {
       name: "Accept",
     });
-    if (consentAcceptButton) await consentAcceptButton.click();
+    if (consentAcceptButton)
+      await consentAcceptButton.click();
   }
 }

--- a/packages/browser/src/integration-tests/helpers/TestHelper.ts
+++ b/packages/browser/src/integration-tests/helpers/TestHelper.ts
@@ -37,8 +37,7 @@ export class TestHelper {
 
     const user = localStorage.find((s) => s.name.startsWith("oidc.user"));
 
-    if (!user)
-      throw new Error("Could not find user in localStorage");
+    if (!user) throw new Error("Could not find user in localStorage");
 
     return User.fromStorageString(user.value);
   }
@@ -53,8 +52,9 @@ export class TestHelper {
     expect(user.access_token).toBeDefined();
 
     let url = `${this._signInOptions.url}/`;
-    if (authType === AuthType.PopUp)
-      url += "signin-via-popup";
+    if (authType === AuthType.PopUp) url += "signin-via-popup";
+    if (authType === AuthType.RedirectStatic)
+      url = "http://localhost:1234/?callbackFromStorage=true";
 
     expect(page.url()).toEqual(url);
   }
@@ -63,7 +63,6 @@ export class TestHelper {
     const consentAcceptButton = page.getByRole("link", {
       name: "Accept",
     });
-    if (consentAcceptButton)
-      await consentAcceptButton.click();
+    if (consentAcceptButton) await consentAcceptButton.click();
   }
 }

--- a/packages/browser/src/integration-tests/integration.test.ts
+++ b/packages/browser/src/integration-tests/integration.test.ts
@@ -30,10 +30,10 @@ test("signin redirect", async ({ page }) => {
 });
 
 test("signin redirect - callback settings from storage", async ({ page }) => {
-  const url = `${signInOptions.url}?callbackFromStorage=true`;
-  await page.goto(url);
+  const staticCallbackUrl = `${signInOptions.url}?callbackFromStorage=true`;
+  await page.goto(staticCallbackUrl);
   await testHelper.signIn(page);
-  await page.waitForURL(url);
+  await page.waitForURL(staticCallbackUrl);
 
   await testHelper.validateAuthenticated(page, AuthType.RedirectStatic);
 });

--- a/packages/browser/src/integration-tests/integration.test.ts
+++ b/packages/browser/src/integration-tests/integration.test.ts
@@ -29,6 +29,15 @@ test("signin redirect", async ({ page }) => {
   await testHelper.validateAuthenticated(page);
 });
 
+test("signin redirect - callback settings from storage", async ({ page }) => {
+  const url = `${signInOptions.url}?callbackFromStorage=true`;
+  await page.goto(url);
+  await testHelper.signIn(page);
+  await page.waitForURL(url);
+
+  await testHelper.validateAuthenticated(page, AuthType.RedirectStatic);
+});
+
 test("signout redirect", async ({ page }) => {
   await page.goto(signInOptions.url);
   await testHelper.signIn(page);

--- a/packages/browser/src/integration-tests/test-app/index.ts
+++ b/packages/browser/src/integration-tests/test-app/index.ts
@@ -25,7 +25,8 @@ async function initialize() {
   }
 
   if (isSignoutPage()) {
-    if (contentArea) contentArea.textContent = "Signed Out!";
+    if (contentArea)
+      contentArea.textContent = "Signed Out!";
   } else if (isSigninViaPopupPage()) {
     const popupButton = document.getElementById("popup");
     if (popupButton)
@@ -62,8 +63,10 @@ async function validateAuthenticated() {
 }
 
 async function signout(popup: boolean) {
-  if (popup) await client.signOutPopup();
-  else await client.signOutRedirect();
+  if (popup)
+    await client.signOutPopup();
+  else
+    await client.signOutRedirect();
 }
 
 function displayAuthorized() {

--- a/packages/browser/src/integration-tests/test-app/index.ts
+++ b/packages/browser/src/integration-tests/test-app/index.ts
@@ -18,11 +18,14 @@ const client = new BrowserAuthorizationClient({
 });
 
 const contentArea = document.querySelector("div[data-testid='content']");
-
+let useStaticCallback = false;
 async function initialize() {
+  if (window.location.search.includes("callbackFromStorage=true")) {
+    useStaticCallback = true;
+  }
+
   if (isSignoutPage()) {
-    if (contentArea)
-      contentArea.textContent = "Signed Out!";
+    if (contentArea) contentArea.textContent = "Signed Out!";
   } else if (isSigninViaPopupPage()) {
     const popupButton = document.getElementById("popup");
     if (popupButton)
@@ -37,7 +40,9 @@ async function initialize() {
   }
 
   if (isOidcCallbackPage()) {
-    await client.handleSigninCallback();
+    useStaticCallback
+      ? await BrowserAuthorizationClient.handleSignInCallback()
+      : await client.handleSigninCallback();
   }
 }
 
@@ -57,10 +62,8 @@ async function validateAuthenticated() {
 }
 
 async function signout(popup: boolean) {
-  if (popup)
-    await client.signOutPopup();
-  else
-    await client.signOutRedirect();
+  if (popup) await client.signOutPopup();
+  else await client.signOutRedirect();
 }
 
 function displayAuthorized() {

--- a/packages/browser/src/integration-tests/types.ts
+++ b/packages/browser/src/integration-tests/types.ts
@@ -9,4 +9,5 @@ export interface SignInOptions {
 export enum AuthType {
   Redirect,
   PopUp,
+  RedirectStatic,
 }

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -68,12 +68,12 @@ export interface BrowserAuthorizationClientRequestOptions {
 export interface SettingsInStorage {
   id: string; // nonce/state
   authority: string;
-  client_id: string;
-  code_verifier: string;
+  client_id: string; // eslint-disable-line @typescript-eslint/naming-convention
+  code_verifier: string; // eslint-disable-line @typescript-eslint/naming-convention
   created: number;
   data: { successRedirectUrl: string };
-  redirect_uri: string;
-  request_type: string;
-  response_mode: string;
+  redirect_uri: string; // eslint-disable-line @typescript-eslint/naming-convention
+  request_type: string; // eslint-disable-line @typescript-eslint/naming-convention
+  response_mode: string; // eslint-disable-line @typescript-eslint/naming-convention
   scope: string;
 }

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -64,3 +64,16 @@ export interface BrowserAuthorizationClientRequestOptions {
   /** The required action demanded of the user before the authentication request can succeed */
   prompt?: "none" | "login" | "consent" | "select_account" | string;
 }
+
+export interface SettingsInStorage {
+  id: string; // nonce/state
+  authority: string;
+  client_id: string;
+  code_verifier: string;
+  created: number;
+  data: { successRedirectUrl: string };
+  redirect_uri: string;
+  request_type: string;
+  response_mode: string;
+  scope: string;
+}


### PR DESCRIPTION
After recent changes, we required an instance of a fully configured `BrowserAuthorizationClient` to call `handleSigninCallback()`. This change adds a new static method which automatically pulls client configuration from local storage. Conveniently, OIDC stores the config using the returned `state` nonce as a key, so we use that to ensure the correct configuration is being selected (consider the case of multiple clients, or possibly stale clients).