### PR TITLE
fix flakey macos electron test

### DIFF
--- a/common/scripts/find_test_flake.sh
+++ b/common/scripts/find_test_flake.sh
@@ -1,0 +1,16 @@
+declare -i counter=0
+while true
+do
+    counter=$(($counter + 1))
+    rush cover
+
+    echo "\n[flakester] ran $counter times\n"
+
+    if [ $? -eq 0 ]
+    then
+        echo "[flakester] All tests passed."
+    else
+        echo "[flakester] A test failed. Stopping."
+        exit 1
+    fi
+done

--- a/packages/electron/src/test/MainAuthorizationClient.test.ts
+++ b/packages/electron/src/test/MainAuthorizationClient.test.ts
@@ -13,6 +13,7 @@ import { ElectronMainAuthorization } from "../main/Client";
 import { ElectronMainAuthorizationRequestHandler } from "../main/ElectronMainAuthorizationRequestHandler";
 import { LoopbackWebServer } from "../main/LoopbackWebServer";
 import { RefreshTokenStore } from "../main/TokenStore";
+import * as keytar from "keytar";
 /* eslint-disable @typescript-eslint/naming-convention */
 const assert = chai.assert;
 const expect = chai.expect;
@@ -43,6 +44,7 @@ describe("ElectronMainAuthorization Token Logic", () => {
     sinon.stub(ElectronMainAuthorization.prototype, "setupIPCHandlers" as any);
     sinon.stub(ElectronMainAuthorization.prototype, "notifyFrontendAccessTokenChange" as any);
     sinon.stub(ElectronMainAuthorization.prototype, "notifyFrontendAccessTokenExpirationChange" as any);
+    sinon.stub(keytar, "deletePassword") // ideally would not stub more than needed, but deletePassword throws "unknown error" randomly... replacing keytar soon anyway
   });
 
   it("Should throw if not signed in", async () => {


### PR DESCRIPTION
Keytar's `deletePassword` throws an unknown error every once in a while. Reason... undetermined. We'll need to migrate off keytar shortly, so this should be a temporary fix. 