### PR TITLE
pass metadata to oidc-client-ts

### DIFF
--- a/common/changes/@itwin/oidc-signin-tool/no-fetch_2023-06-02-09-03.json
+++ b/common/changes/@itwin/oidc-signin-tool/no-fetch_2023-06-02-09-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/oidc-signin-tool",
+      "comment": "Fix issue with OIDC signin tool not working without fetch API",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/oidc-signin-tool"
+}

--- a/packages/oidc-signin-tool/package.json
+++ b/packages/oidc-signin-tool/package.json
@@ -61,7 +61,7 @@
     "typescript": "~4.3.5"
   },
   "peerDependencies": {
-    "@itwin/core-bentley": ">=3.3.0"
+    "@itwin/core-bentley": "^3.3.0 || ^4.0.0"
   },
   "eslintConfig": {
     "plugins": [

--- a/packages/oidc-signin-tool/src/TestBrowserAuthorizationClient.ts
+++ b/packages/oidc-signin-tool/src/TestBrowserAuthorizationClient.ts
@@ -114,6 +114,7 @@ export class TestBrowserAuthorizationClient implements AuthorizationClient {
       client_id: this._config.clientId,
       stateStore: new WebStorageStateStore({ store: new InMemoryWebStorage() }),
       scope: this._config.scope,
+      metadata: config,
     });
 
     // this is only async because it _could_ use AsyncStorage browser API.


### PR DESCRIPTION
Without this metadata, the client uses `fetch` to get issuer metadata, which is not always available (especially in older Node.js versions)