### PR TITLE
fix version ranges

### DIFF
--- a/common/changes/@itwin/browser-authorization/fix-ranges_2023-07-19-12-08.json
+++ b/common/changes/@itwin/browser-authorization/fix-ranges_2023-07-19-12-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix dependency version ranges",
+      "type": "patch",
+      "packageName": "@itwin/browser-authorization"
+    }
+  ],
+  "packageName": "@itwin/browser-authorization",
+  "email": "66480813+paulius-valiunas@users.noreply.github.com"
+}

--- a/common/changes/@itwin/electron-authorization/fix-ranges_2023-07-19-12-08.json
+++ b/common/changes/@itwin/electron-authorization/fix-ranges_2023-07-19-12-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix dependency version ranges",
+      "type": "patch",
+      "packageName": "@itwin/electron-authorization"
+    }
+  ],
+  "packageName": "@itwin/electron-authorization",
+  "email": "66480813+paulius-valiunas@users.noreply.github.com"
+}

--- a/common/changes/@itwin/node-cli-authorization/fix-ranges_2023-07-19-12-08.json
+++ b/common/changes/@itwin/node-cli-authorization/fix-ranges_2023-07-19-12-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix dependency version ranges",
+      "type": "patch",
+      "packageName": "@itwin/node-cli-authorization"
+    }
+  ],
+  "packageName": "@itwin/node-cli-authorization",
+  "email": "66480813+paulius-valiunas@users.noreply.github.com"
+}

--- a/common/changes/@itwin/oidc-signin-tool/fix-ranges_2023-07-19-12-08.json
+++ b/common/changes/@itwin/oidc-signin-tool/fix-ranges_2023-07-19-12-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix dependency version ranges",
+      "type": "patch",
+      "packageName": "@itwin/oidc-signin-tool"
+    }
+  ],
+  "packageName": "@itwin/oidc-signin-tool",
+  "email": "66480813+paulius-valiunas@users.noreply.github.com"
+}

--- a/common/changes/@itwin/service-authorization/fix-ranges_2023-07-19-12-08.json
+++ b/common/changes/@itwin/service-authorization/fix-ranges_2023-07-19-12-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix dependency version ranges",
+      "type": "patch",
+      "packageName": "@itwin/service-authorization"
+    }
+  ],
+  "packageName": "@itwin/service-authorization",
+  "email": "66480813+paulius-valiunas@users.noreply.github.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
     specifiers:
       '@itwin/build-tools': ^4.0.0-dev.93
       '@itwin/core-bentley': ^3.7.0
-      '@itwin/core-common': '>=3.7.0'
+      '@itwin/core-common': ^3.7.0 || ^4.0.0
       '@itwin/eslint-plugin': ^3.7.0
       '@playwright/test': ~1.35.1
       '@types/chai': ^4.2.22
@@ -60,7 +60,7 @@ importers:
     specifiers:
       '@itwin/build-tools': ^4.0.0-dev.93
       '@itwin/core-bentley': ^3.7.0
-      '@itwin/core-common': '>=3.3.0'
+      '@itwin/core-common': ^3.3.0 || ^4.0.0
       '@itwin/eslint-plugin': ^3.3.0
       '@openid/appauth': ^1.3.1
       '@playwright/test': ~1.35.1
@@ -119,7 +119,7 @@ importers:
     specifiers:
       '@itwin/build-tools': ^4.0.0-dev.93
       '@itwin/core-bentley': ^3.7.0
-      '@itwin/core-common': '>=3.3.0'
+      '@itwin/core-common': ^3.3.0 || ^4.0.0
       '@itwin/eslint-plugin': ^3.7.0
       '@openid/appauth': ^1.3.1
       '@types/chai': ^4.2.22
@@ -165,7 +165,7 @@ importers:
       '@itwin/build-tools': ^4.0.0-dev.93
       '@itwin/certa': ^3.7.0
       '@itwin/core-bentley': ^3.7.0
-      '@itwin/core-common': '>=3.3.0'
+      '@itwin/core-common': ^3.3.0 || ^4.0.0
       '@itwin/eslint-plugin': ^3.7.0
       '@itwin/service-authorization': workspace:*
       '@playwright/test': ~1.35.1
@@ -217,7 +217,7 @@ importers:
     specifiers:
       '@itwin/build-tools': ^4.0.0-dev.93
       '@itwin/core-bentley': ^3.7.0
-      '@itwin/core-common': '>=3.3.0'
+      '@itwin/core-common': ^3.3.0 || ^4.0.0
       '@itwin/eslint-plugin': ^3.7.0
       '@types/chai': ^4.2.22
       '@types/chai-as-promised': ^7
@@ -657,7 +657,7 @@ packages:
     dev: false
 
   /@itwin/cloud-agnostic-core/1.6.0:
-    resolution: {integrity: sha1-dEtUKIMGJVCRow1mnsILNmz+kLM=}
+    resolution: {integrity: sha512-IKj3lxaVQqGezz7bkFjKEf9g7Bk4i2cu2aCJsd9HnV2gn79lo8oU0UiPJ+kuVtMsEcN/yRq/EXk/IR/VnNkLKA==}
     engines: {node: '>=12.20 <19.0.0'}
     dependencies:
       inversify: 5.0.5
@@ -668,7 +668,7 @@ packages:
     resolution: {integrity: sha1-TfuP2Bf9v9nq6MSJnsXWvsOna+Y=}
 
   /@itwin/core-common/3.7.6_@itwin+core-bentley@3.7.6:
-    resolution: {integrity: sha1-xYqc49IbZx1edWUDHR4fE+EFwS8=}
+    resolution: {integrity: sha512-XVeMJ9I6zKUA0tLXJY1GPYbNmnT7xAfsH4KLnAEfb5rujiO19YSoShpDxqFLHkM9z0b2qJaOsbsnOsZRjypyFg==}
     peerDependencies:
       '@itwin/core-bentley': ^3.7.6
       '@itwin/core-geometry': ^3.7.6
@@ -735,7 +735,7 @@ packages:
     dev: true
 
   /@itwin/object-storage-core/1.6.0:
-    resolution: {integrity: sha1-IYwGkgnYmxAYDjI9w+IW8BWq3Hg=}
+    resolution: {integrity: sha512-6X6YZ5E/kSJJlKQm7+xluzBGBGPILlEmEfzBgEcDqEwABS214OcKU74kW5mfrB6AiNXKZ2RkxfafW/ZpYi24fg==}
     engines: {node: '>=12.20 <19.0.0'}
     dependencies:
       '@itwin/cloud-agnostic-core': 1.6.0
@@ -1795,7 +1795,7 @@ packages:
     dev: true
 
   /@sindresorhus/is/4.6.0:
-    resolution: {integrity: sha1-PHycRuZ4/u/nouW7YJ09vWZf+z8=}
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
   /@sinonjs/commons/2.0.0:
@@ -1835,7 +1835,7 @@ packages:
     dev: true
 
   /@szmarczak/http-timer/4.0.6:
-    resolution: {integrity: sha1-tKkUu2LnwnLU5Zif5EQPgSqx2Ac=}
+    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
     dependencies:
       defer-to-connect: 2.0.1
@@ -1861,7 +1861,7 @@ packages:
     dev: false
 
   /@types/cacheable-request/6.0.3:
-    resolution: {integrity: sha1-pDCzJgRmyntcpb/XNWk7Nuep0YM=}
+    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
     dependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/keyv': 3.1.4
@@ -1903,7 +1903,7 @@ packages:
     dev: false
 
   /@types/http-cache-semantics/4.0.1:
-    resolution: {integrity: sha1-Dqe2FJaQK5WJDcTDoRa2DLja6BI=}
+    resolution: {integrity: sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==}
 
   /@types/jquery/3.5.16:
     resolution: {integrity: sha1-YyExuvMJUZFbAxfUjJjpiQvfBR0=}
@@ -1931,7 +1931,7 @@ packages:
     dev: true
 
   /@types/keyv/3.1.4:
-    resolution: {integrity: sha1-PM2xxnUbDH5SMAvNrNW8v4+qdbY=}
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
       '@types/node': 20.1.7
 
@@ -1967,7 +1967,7 @@ packages:
     dev: false
 
   /@types/responselike/1.0.0:
-    resolution: {integrity: sha1-JR9P59FU0rrRJavhtCmyOv0mLik=}
+    resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
       '@types/node': 20.1.7
 
@@ -2531,7 +2531,7 @@ packages:
     dev: true
 
   /axios/0.27.2:
-    resolution: {integrity: sha1-IHZYzIYhYG5YbIXbS0GnUOdW2XI=}
+    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
       follow-redirects: 1.15.2
       form-data: 4.0.0
@@ -2657,11 +2657,11 @@ packages:
     dev: false
 
   /cacheable-lookup/5.0.4:
-    resolution: {integrity: sha1-WmuGWyxENXvj1evCpGewMnGacAU=}
+    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
     engines: {node: '>=10.6.0'}
 
   /cacheable-request/7.0.2:
-    resolution: {integrity: sha1-6g0LiJNkolhUdXMByhKy2nf5HSc=}
+    resolution: {integrity: sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==}
     engines: {node: '>=8'}
     dependencies:
       clone-response: 1.0.3
@@ -2827,7 +2827,7 @@ packages:
       wrap-ansi: 7.0.0
 
   /clone-response/1.0.3:
-    resolution: {integrity: sha1-ryAyqkeBY5nPXwodDbkC9ReruMM=}
+    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
     dependencies:
       mimic-response: 1.0.1
 
@@ -3087,7 +3087,7 @@ packages:
     engines: {node: '>=10'}
 
   /decompress-response/6.0.0:
-    resolution: {integrity: sha1-yjh2Et234QS9FthaqwDV7PCcZvw=}
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
     dependencies:
       mimic-response: 3.1.0
@@ -3139,7 +3139,7 @@ packages:
     dev: true
 
   /defer-to-connect/2.0.1:
-    resolution: {integrity: sha1-gBa9tBQ+RjK3ejRJxiNid95SBYc=}
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
     engines: {node: '>=10'}
 
   /define-lazy-prop/2.0.0:
@@ -3318,7 +3318,7 @@ packages:
     dev: false
 
   /end-of-stream/1.4.4:
-    resolution: {integrity: sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=}
+    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
       once: 1.4.0
 
@@ -3949,7 +3949,7 @@ packages:
     hasBin: true
 
   /flatbuffers/1.12.0:
-    resolution: {integrity: sha1-cuh9FybLGyFug57wJliqh9zvaKo=}
+    resolution: {integrity: sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==}
     dev: false
 
   /flatted/3.2.7:
@@ -4104,7 +4104,7 @@ packages:
     dev: false
 
   /get-stream/5.2.0:
-    resolution: {integrity: sha1-SWaheV7lrOZecGxLe+txJX1uItM=}
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
     dependencies:
       pump: 3.0.0
@@ -4217,7 +4217,7 @@ packages:
     dev: true
 
   /got/11.8.6:
-    resolution: {integrity: sha1-J26Cfq2Hcu3bz8lxcFkLhBgjIzo=}
+    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
     engines: {node: '>=10.19.0'}
     dependencies:
       '@sindresorhus/is': 4.6.0
@@ -4342,7 +4342,7 @@ packages:
     dev: true
 
   /http-cache-semantics/4.1.1:
-    resolution: {integrity: sha1-q+AvyymFRgvwMjvmZENuw0dqbVo=}
+    resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
 
   /http-errors/2.0.0:
     resolution: {integrity: sha1-t3dKFIbvc892Z6ya4IWMASxXudM=}
@@ -4356,7 +4356,7 @@ packages:
     dev: false
 
   /http2-wrapper/1.0.3:
-    resolution: {integrity: sha1-uPVeDB8l1OvQizsMLAeflZCACz0=}
+    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
     engines: {node: '>=10.19.0'}
     dependencies:
       quick-lru: 5.1.1
@@ -4438,7 +4438,7 @@ packages:
     dev: true
 
   /inversify/5.0.5:
-    resolution: {integrity: sha1-vR+ObY4Pc5MxrNi6m8lUY1quC78=}
+    resolution: {integrity: sha512-60QsfPz8NAU/GZqXu8hJ+BhNf/C/c+Hp0eDc6XMIJTxBiP36AQyyQKpBkOVTLWBFDQWYVHpbbEuIsHu9dLuJDA==}
     dev: false
 
   /ipaddr.js/1.9.1:
@@ -4738,7 +4738,7 @@ packages:
     dev: false
 
   /js-base64/3.7.5:
-    resolution: {integrity: sha1-IeJM9riG921vXxZb/NacxVueP8o=}
+    resolution: {integrity: sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA==}
     dev: false
 
   /js-tokens/4.0.0:
@@ -4783,7 +4783,7 @@ packages:
     dev: true
 
   /json-buffer/3.0.1:
-    resolution: {integrity: sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=}
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
   /json-parse-even-better-errors/2.3.1:
     resolution: {integrity: sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0=}
@@ -4905,7 +4905,7 @@ packages:
     dev: false
 
   /keyv/4.5.2:
-    resolution: {integrity: sha1-DjEM5zv3hR7HAvLq9G7E44BczlY=}
+    resolution: {integrity: sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==}
     dependencies:
       json-buffer: 3.0.1
 
@@ -5108,7 +5108,7 @@ packages:
     dev: true
 
   /lowercase-keys/2.0.0:
-    resolution: {integrity: sha1-JgPni3tLAAbLyi+8yKMgJVislHk=}
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
 
   /lru-cache/4.0.2:
@@ -5119,13 +5119,13 @@ packages:
     dev: false
 
   /lru-cache/5.1.1:
-    resolution: {integrity: sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=}
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
     dependencies:
       yallist: 3.1.1
     dev: true
 
   /lru-cache/6.0.0:
-    resolution: {integrity: sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=}
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
@@ -5241,11 +5241,11 @@ packages:
     dev: false
 
   /mimic-response/1.0.1:
-    resolution: {integrity: sha1-SSNTiHju9CBjy4o+OweYeBSHqxs=}
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
     engines: {node: '>=4'}
 
   /mimic-response/3.1.0:
-    resolution: {integrity: sha1-LR1Zr5wbEpgVrMwsRqAipc4fo8k=}
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
   /minimatch/3.0.4:
@@ -5486,7 +5486,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   /normalize-url/6.1.0:
-    resolution: {integrity: sha1-QNCIW1Nd7/4/MUe+yHfQX+TFZoo=}
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
   /npm-run-path/2.0.2:
@@ -5658,7 +5658,7 @@ packages:
     dev: true
 
   /p-cancelable/2.1.1:
-    resolution: {integrity: sha1-qrf71BZYL6MqPbSYWcEiSHxe0s8=}
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
     engines: {node: '>=8'}
 
   /p-defer/1.0.0:
@@ -5937,7 +5937,7 @@ packages:
     dev: false
 
   /pump/3.0.0:
-    resolution: {integrity: sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=}
+    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
@@ -5983,7 +5983,7 @@ packages:
     dev: true
 
   /quick-lru/5.1.1:
-    resolution: {integrity: sha1-NmST5rPkKjpoheLpnRj4D7eoyTI=}
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
   /randombytes/2.1.0:
@@ -6052,7 +6052,7 @@ packages:
       picomatch: 2.3.1
 
   /reflect-metadata/0.1.13:
-    resolution: {integrity: sha1-Z648pXyXKiqhZCsQ/jY/4y1J3Ag=}
+    resolution: {integrity: sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==}
     dev: false
 
   /regenerator-runtime/0.13.11:
@@ -6108,7 +6108,7 @@ packages:
     dev: true
 
   /resolve-alpn/1.2.1:
-    resolution: {integrity: sha1-t629rDVGqq7CC0Xn2CZZJwcnJvk=}
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
 
   /resolve-from/4.0.0:
     resolution: {integrity: sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=}
@@ -6146,7 +6146,7 @@ packages:
     dev: true
 
   /responselike/2.0.1:
-    resolution: {integrity: sha1-mgvI/cJS8/scymiwFlkQWboUIrw=}
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
     dependencies:
       lowercase-keys: 2.0.0
 
@@ -6201,7 +6201,7 @@ packages:
     optional: true
 
   /semver/5.7.1:
-    resolution: {integrity: sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=}
+    resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
     hasBin: true
 
   /semver/6.3.0:
@@ -6218,7 +6218,7 @@ packages:
     dev: true
 
   /semver/7.5.1:
-    resolution: {integrity: sha1-yQxNYxz3RyDkayHB036gft+rkew=}
+    resolution: {integrity: sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -7060,11 +7060,11 @@ packages:
     dev: false
 
   /yallist/3.1.1:
-    resolution: {integrity: sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=}
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
     dev: true
 
   /yallist/4.0.0:
-    resolution: {integrity: sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=}
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   /yargs-parser/18.1.3:
     resolution: {integrity: sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=}

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -31,7 +31,7 @@
     "directory": "packages/browser"
   },
   "dependencies": {
-    "@itwin/core-common": ">=3.7.0",
+    "@itwin/core-common": "^3.7.0 || ^4.0.0",
     "oidc-client-ts": "^2.2.0"
   },
   "devDependencies": {
@@ -56,7 +56,7 @@
     "typescript": "~4.3.5"
   },
   "peerDependencies": {
-    "@itwin/core-bentley": ">=3.3.0"
+    "@itwin/core-bentley": "^3.3.0 || ^4.0.0"
   },
   "eslintConfig": {
     "plugins": [

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -29,7 +29,7 @@
     "directory": "packages/electron"
   },
   "dependencies": {
-    "@itwin/core-common": ">=3.3.0",
+    "@itwin/core-common": "^3.3.0 || ^4.0.0",
     "@openid/appauth": "^1.3.1",
     "keytar": "^7.8.0",
     "username": "^5.1.0"
@@ -60,7 +60,7 @@
     "typescript": "~4.3.5"
   },
   "peerDependencies": {
-    "@itwin/core-bentley": ">=3.3.0",
+    "@itwin/core-bentley": "^3.3.0 || ^4.0.0",
     "electron": ">=23.0.0 <25.0.0"
   },
   "eslintConfig": {

--- a/packages/node-cli/package.json
+++ b/packages/node-cli/package.json
@@ -27,7 +27,7 @@
     "directory": "packages/node-cli"
   },
   "dependencies": {
-    "@itwin/core-common": ">=3.3.0",
+    "@itwin/core-common": "^3.3.0 || ^4.0.0",
     "@openid/appauth": "^1.3.1",
     "keytar": "^7.8.0",
     "open": "^8.3.0",
@@ -51,7 +51,7 @@
     "typescript": "~4.3.5"
   },
   "peerDependencies": {
-    "@itwin/core-bentley": ">=3.3.0"
+    "@itwin/core-bentley": "^3.3.0 || ^4.0.0"
   },
   "eslintConfig": {
     "plugins": [

--- a/packages/oidc-signin-tool/package.json
+++ b/packages/oidc-signin-tool/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@itwin/certa": "^3.7.0",
-    "@itwin/core-common": ">=3.3.0",
+    "@itwin/core-common": "^3.3.0 || ^4.0.0",
     "@itwin/service-authorization": "workspace:*",
     "@playwright/test": "~1.35.1",
     "dotenv": "^10.0.0",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -27,7 +27,7 @@
     "directory": "packages/service"
   },
   "dependencies": {
-    "@itwin/core-common": ">=3.3.0",
+    "@itwin/core-common": "^3.3.0 || ^4.0.0",
     "got": "^11.8.6",
     "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^2.0.4"


### PR DESCRIPTION
we shot ourselves in the leg by using `>=` for dependencies. Once we release iTwin.js 5.0, we'll be in deep trouble if anyone is still using the current versions of auth clients. Since we don't update them often, that might be very likely. I decided to just do a separate patch release for this, to ensure that as many people as possible get it. Including it in an unrelated minor/major release would mean that people using `~` version ranges to pull in auth clients wouldn't get the update.