### PR TITLE
Fix publish pipeline attempt 2

### DIFF
--- a/common/config/azure-pipelines/ci.yml
+++ b/common/config/azure-pipelines/ci.yml
@@ -96,12 +96,3 @@ stages:
       - template: templates/build-docs.yaml
         parameters:
           shouldPublish: ${{ parameters.shouldPublish }}
-
-- stage: Validate_Docs
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'PullRequest', 'Manual'))
-  jobs:
-  - template: common/config/azure-pipelines/jobs/docs-build.yaml@itwinjs-core
-    parameters:
-      checkout: itwinjs-core
-      useCurrentAuthClientsDocsArtifact: true
-      ignoreAudit: true

--- a/common/config/azure-pipelines/ci.yml
+++ b/common/config/azure-pipelines/ci.yml
@@ -98,7 +98,6 @@ stages:
           shouldPublish: ${{ parameters.shouldPublish }}
 
 - stage: Validate_Docs
-  dependsOn: Generate_Docs
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'PullRequest', 'Manual'))
   jobs:
   - template: common/config/azure-pipelines/jobs/docs-build.yaml@itwinjs-core


### PR DESCRIPTION
No reason to validate the docs at that point in the publishing workflow, at least not in that manner.