### PR TITLE
add info about postSignoutRedirectUri quirk to browser-auth readme

### DIFF
--- a/common/changes/@itwin/browser-authorization/add-logout-url-note-readme_2023-08-02-20-23.json
+++ b/common/changes/@itwin/browser-authorization/add-logout-url-note-readme_2023-08-02-20-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/browser-authorization",
+      "comment": "update readme",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/browser-authorization"
+}

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -22,7 +22,7 @@ const client = new BrowserAuthorizationClient({
 });
 ```
 
-> Important! The above `postSignoutRedirectUri` will not fully work if the url ends with /logout and https is not supported on your site. We suggest using /logout-local if you run into this issue.
+> Important! The above `postSignoutRedirectUri` will not fully work if the url ends with /logout and https is not supported on your site. For local development where https is less common, we suggest using /logout-local for the url path.
 
 The most common way to use an instance of `BrowserAuthorizationClient` will depend on your specific application and workflow. Here's one common way:
 

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -16,11 +16,13 @@ const client = new BrowserAuthorizationClient({
   redirectUri: // find/set at developer.bentley.com
   scope: // find/set at developer.bentley.com
   authority: // ims.bentley.com
-  postSignoutRedirectUri: // find/set at developer.bentley.com
+  postSignoutRedirectUri: // find/set at developer.bentley.com (see note below)
   responseType: "code",
   silentRedirectUri: // find/set at developer.bentley.com
 });
 ```
+
+> Important! The above `postSignoutRedirectUri` will not fully work if the url ends with /logout and https is not supported on your site. We suggest using /logout-local if you run into this issue.
 
 The most common way to use an instance of `BrowserAuthorizationClient` will depend on your specific application and workflow. Here's one common way:
 


### PR DESCRIPTION
Cannot use `/logout` as postSignoutRedirectUri when redirecting to http. Added guidance in readme.