### PR TITLE
Add ablity to remove persisted response in case of windows

### DIFF
--- a/packages/node-cli/src/TokenStore.ts
+++ b/packages/node-cli/src/TokenStore.ts
@@ -10,7 +10,7 @@ import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "node:
 import * as path from "node:path";
 import * as NodePersist from "node-persist";
 
-type CacheEntry = TokenResponseJson & {scopesForCacheValidation?: string};
+type CacheEntry = TokenResponseJson & { scopesForCacheValidation?: string };
 /**
  * Utility to store OIDC AppAuth in secure storage
  * @internal
@@ -19,7 +19,7 @@ export class TokenStore {
   private readonly _appStorageKey: string;
   private readonly _scopes: string;
   private readonly _store: NodePersist.LocalStorage;
-  public constructor(namedArgs: {clientId: string, issuerUrl: string, scopes: string}, dir?: string) {
+  public constructor(namedArgs: { clientId: string, issuerUrl: string, scopes: string }, dir?: string) {
     // A stored credential is only valid for a combination of the clientId, the issuing authority and the requested scopes.
     // We make the storage key a combination of clientId and issuing authority so that keys can stay cached when switching
     // between PROD and QA environments.
@@ -60,7 +60,7 @@ export class TokenStore {
    * Uses node's native `crypto` module to encrypt the given cache entry.
    * @returns an object containing a hexadecimal encoded token, returned as a string, as well as the initialization vector.
    */
-  private encryptCache(cacheEntry: CacheEntry): {encryptedCache: string, iv: string} {
+  private encryptCache(cacheEntry: CacheEntry): { encryptedCache: string, iv: string } {
     const iv = randomBytes(16);
     const cipher = createCipheriv("aes-256-cbc", this.generateCipherKey(), iv);
 
@@ -103,6 +103,14 @@ export class TokenStore {
     delete tokenResponseObj.scopesForCacheValidation;
 
     return new TokenResponse(tokenResponseObj);
+  }
+
+  public async remove(): Promise<void> {
+    if (process.platform === "linux")
+      return;
+
+    const key = await this.getKey();
+    await this._store.removeItem(key);
   }
 
   public async save(tokenResponse: TokenResponse): Promise<void> {

--- a/packages/node-cli/src/test/TokenStore.test.ts
+++ b/packages/node-cli/src/test/TokenStore.test.ts
@@ -35,7 +35,20 @@ describe("TokenStore", () => {
     await tokenStore.save(testTokenResponse);
     chai.assert.isTrue(saveSpy.calledOnce);
   });
+  it("should be able to remove response", async () => {
+    if (process.platform === "linux")
+      return;
 
+    await tokenStore.save(testTokenResponse);
+
+    let retrievedToken = await tokenStore.load();
+    chai.expect(retrievedToken!.refreshToken).equals(testTokenResponse.refreshToken);
+
+    await tokenStore.remove();
+
+    retrievedToken = await tokenStore.load();
+    chai.assert(typeof retrievedToken === "undefined");
+  });
   it("should decrypt cache on load", async () => {
     if (process.platform === "linux")
       return;


### PR DESCRIPTION
Sometime refresh token expires and user must go an manually delete setting from
window network password otherwise app will not login or get new token. This PR
add ability to forget refresh token if signIn() fail to refresh token. This PR
also add method to explicitly signOut() and forget persisted token so new sign
can take place.

* Add signout() method to node-cli
* Add remove() method to TokenStore