### PR TITLE
Replace playwright `type` calls with `fill`

### DIFF
--- a/change/@itwin-oidc-signin-tool-ca6fd177-8f76-4fe4-afb8-ea94ece5d83c.json
+++ b/change/@itwin-oidc-signin-tool-ca6fd177-8f76-4fe4-afb8-ea94ece5d83c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Refactor login form handling in SignInAutomation.ts to use .fill",
+  "packageName": "@itwin/oidc-signin-tool",
+  "email": "19596966+johnnyd710@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/oidc-signin-tool/src/SignInAutomation.ts
+++ b/packages/oidc-signin-tool/src/SignInAutomation.ts
@@ -129,10 +129,8 @@ async function handleLoginPage<T>(context: AutomatedSignInContext<T>): Promise<v
   const loginUrl = new URL("/IMS/Account/Login", context.config.issuer);
   const { page } = context;
   if (page.url().startsWith(loginUrl.toString())) {
-    await page.waitForSelector(testSelectors.imsEmail);
-    await page.type(testSelectors.imsEmail, context.user.email);
-    await page.waitForSelector(testSelectors.imsPassword);
-    await page.type(testSelectors.imsPassword, context.user.password);
+    await page.locator(testSelectors.imsEmail).fill(context.user.email);
+    await page.locator(testSelectors.imsPassword).fill(context.user.password);
 
     const submit = page.locator(testSelectors.imsSubmit);
     await submit.click();
@@ -152,8 +150,7 @@ async function handlePingLoginPage<T>(context: AutomatedSignInContext<T>): Promi
   )
     return;
 
-  await page.waitForSelector(testSelectors.pingEmail);
-  await page.type(testSelectors.pingEmail, context.user.email);
+  await page.locator(testSelectors.pingEmail).fill(context.user.email);
 
   await page.waitForSelector(testSelectors.pingAllowSubmit);
   let allow = page.locator(testSelectors.pingAllowSubmit);
@@ -163,8 +160,7 @@ async function handlePingLoginPage<T>(context: AutomatedSignInContext<T>): Promi
   if (-1 !== page.url().indexOf("microsoftonline"))
     return;
 
-  await page.waitForSelector(testSelectors.pingPassword);
-  await page.type(testSelectors.pingPassword, context.user.password);
+  await page.locator(testSelectors.pingPassword).fill(context.user.password);
 
   await page.waitForSelector(testSelectors.pingAllowSubmit);
   allow = page.locator(testSelectors.pingAllowSubmit);
@@ -196,19 +192,17 @@ async function handleFederatedSignin<T>(context: AutomatedSignInContext<T>): Pro
     return;
 
   if (await checkSelectorExists(page, testSelectors.msUserNameField)) {
-    await page.type(testSelectors.msUserNameField, context.user.email);
+    await page.locator(testSelectors.msUserNameField).fill(context.user.email);
     const msSubmit = await page.waitForSelector(testSelectors.msSubmit);
     await msSubmit.click();
 
     // Checks for the error in username entered
     await checkErrorOnPage(page, "#usernameError");
   } else {
-    const fedEmail = await page.waitForSelector(testSelectors.fedEmail);
-    await fedEmail.type(context.user.email);
+    await page.locator(testSelectors.fedEmail).fill(context.user.email);
   }
 
-  const fedPassword = await page.waitForSelector(testSelectors.fedPassword);
-  await fedPassword.type(context.user.password);
+  await page.locator(testSelectors.fedPassword).fill(context.user.password);
   const submit = await page.waitForSelector(testSelectors.fedSubmit);
   await submit.click();
 

--- a/packages/oidc-signin-tool/src/test-integration/basic.test.ts
+++ b/packages/oidc-signin-tool/src/test-integration/basic.test.ts
@@ -45,7 +45,7 @@ test.describe("Sign in (#integration)", () => {
     await expect(
       getTestAccessToken(oidcConfig, TestUsers.federatedInvalid)
     ).rejects.toThrowError(
-      `Failed OIDC signin for ${TestUsers.federatedInvalid.email}.\nError: Enter a valid email address, phone number, or Skype name.`
+      `Failed OIDC signin for ${TestUsers.federatedInvalid.email}.\nError: This username may be incorrect. Make sure you typed it correctly. Otherwise, contact your admin.`
     );
   });
 


### PR DESCRIPTION
Using `locator.fill` is [the recommended way](https://playwright.dev/docs/input#text-input) to fill out input, and [`Page.type` is now deprecated](https://playwright.dev/docs/api/class-page#page-type).

I made these changes using `pnpm patch` for my Electron application, and I *think* it will close https://github.com/iTwin/auth-clients/issues/224 but I can't be sure because the issue is flaky and doesn't happen frequently.