### PR TITLE
Resolve `signIn` promise when sign in has completed

### DIFF
--- a/change/@itwin-electron-authorization-cb30a53e-3752-4c76-829e-b7017135452b.json
+++ b/change/@itwin-electron-authorization-cb30a53e-3752-4c76-829e-b7017135452b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Resolve ElectronRendererAuthorization signIn when sign in has completed and reject if an error occurs.",
+  "packageName": "@itwin/electron-authorization",
+  "email": "19596966+johnnyd710@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/electron/src/renderer/Client.ts
+++ b/packages/electron/src/renderer/Client.ts
@@ -105,7 +105,11 @@ export class ElectronRendererAuthorization implements AuthorizationClient {
     });
   }
 
-  /** Called to start the sign-in process. Subscribe to onAccessTokenChanged to be notified when sign-in completes */
+  /**
+   * Called to start the sign-in process.
+   * Resolves when sign-in completes, rejects if sign-in fails.
+   * Subscribe to `onAccessTokenChanged` to be notified when a token is available.
+   */
   public async signIn(): Promise<void> {
     await this._ipcAuthAPI.signIn();
   }


### PR DESCRIPTION
tldr: Resolve the `ElectronRendererAuthorization.signIn()` promise when sign-in has fully completed, and reject on errors. Closes https://github.com/iTwin/auth-clients/issues/226.

### Changes
Previously, some sign-in errors (e.g., an internal server error on the token issuer server) were uncaught by `ElectronRendererMain`, and there wasn't a way for consumers of this package to catch it. The frontend who initiated the sign-in was left waiting for `onAccessTokenChanged` forever. Now, we resolve the promise when sign in has actually fully completed or reject the promise if there was an error during sign in, so that the frontend can show an error message.

Technically the API is the same, the types are the same, but the usage could vary slightly.

### Example Usage of `signIn()`

### Before
```jsx
  const onSignInClick = async (): Promise<void> => {
    setSigningIn(true);
    if (IModelApp.authorizationClient instanceof ElectronRendererAuthorization) {
      await IModelApp.authorizationClient.signIn(); // resolves as soon as sign-in starts, with no way to catch errors
    }
  };

  useEffect(() => {
    (IModelApp.authorizationClient as ElectronRendererAuthorization)?.onAccessTokenChanged.addListener(
      (token: AccessToken | undefined) => {
        setAccessToken(token);
        setSigningIn(false);
      }
    );
  });

```

### After
```jsx
  const onSignInClick = async () => {
    setSigningIn(true);
    if (IModelApp.authorizationClient instanceof ElectronRendererAuthorization) {
      try {
        await IModelApp.authorizationClient.signIn(); // resolves after sign in is complete
      } catch (err) {
        LoggingClient.logException(err); // catch errors and do something
        setErrorMessage("Error while signing in, please try again.");
        setSigningIn(false);
      }
    }
  };

  useEffect(() => {
    (IModelApp.authorizationClient as ElectronRendererAuthorization)?.onAccessTokenChanged.addListener(
      (token: AccessToken | undefined) => {
        setAccessToken(token);
        setSigningIn(false);
      }
    );
  });
```