### PR TITLE
Publish static loopback pages

### DIFF
--- a/change/@itwin-electron-authorization-82609d51-3709-4e72-a06c-81f5102e39cc.json
+++ b/change/@itwin-electron-authorization-82609d51-3709-4e72-a06c-81f5102e39cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Publish static HTML loopback files.",
+  "packageName": "@itwin/electron-authorization",
+  "email": "19596966+johnnyd710@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-node-cli-authorization-85c83eb7-603e-450c-90d1-06fe62b6b77c.json
+++ b/change/@itwin-node-cli-authorization-85c83eb7-603e-450c-90d1-06fe62b6b77c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Publish static HTML loopback files.",
+  "packageName": "@itwin/node-cli-authorization",
+  "email": "19596966+johnnyd710@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/electron/.npmignore
+++ b/packages/electron/.npmignore
@@ -5,5 +5,6 @@
 !lib/**/*.js
 !lib/**/*.js.map
 !*.md
+!**/static/**
 
 lib/**/*test*/**/*

--- a/packages/node-cli/.npmignore
+++ b/packages/node-cli/.npmignore
@@ -5,5 +5,6 @@
 !lib/**/*.js
 !lib/**/*.js.map
 !*.md
+!**/static/**
 
 lib/**/test/**


### PR DESCRIPTION
Static loopback pages needed to be published to npm, they were ignored by the `.npmignore` file, resulting in a runtime `ENOENT: no such file or directory`