### PR TITLE
Handle decryptRefreshToken failure

### DIFF
--- a/change/@itwin-electron-authorization-42c4719f-cdb4-4366-a501-63704e26e476.json
+++ b/change/@itwin-electron-authorization-42c4719f-cdb4-4366-a501-63704e26e476.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Handle decryptRefreshToken failure",
+  "packageName": "@itwin/electron-authorization",
+  "email": "17436829+GintV@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/electron/src/main/TokenStore.ts
+++ b/packages/electron/src/main/TokenStore.ts
@@ -76,7 +76,7 @@ export class RefreshTokenStore {
       return undefined;
     }
     const encryptedToken = this._store.get(key);
-    const refreshToken = await this.decryptRefreshToken(encryptedToken);
+    const refreshToken = await this.decryptRefreshToken(encryptedToken).catch(() => undefined);
     return refreshToken;
   }
 

--- a/packages/electron/src/test/MainAuthorizationClient.test.ts
+++ b/packages/electron/src/test/MainAuthorizationClient.test.ts
@@ -74,8 +74,8 @@ describe("ElectronMainAuthorization Token Logic", () => {
     const mockTokenResponse = new TokenResponse(mockTokenResponseJson);
 
     const refreshToken = "old refresh token";
-    sinon.stub(RefreshTokenStore.prototype, "encryptRefreshToken" as any).returns(Buffer.from(refreshToken));
-    sinon.stub(RefreshTokenStore.prototype, "decryptRefreshToken" as any).returns(refreshToken);
+    sinon.stub(RefreshTokenStore.prototype, "encryptRefreshToken" as any).returns(Promise.resolve(Buffer.from(refreshToken)));
+    sinon.stub(RefreshTokenStore.prototype, "decryptRefreshToken" as any).returns(Promise.resolve(refreshToken));
     // Load refresh token into token store - use clientId
     const tokenStore = new RefreshTokenStore(getTokenStoreFileName(config.clientId),getTokenStoreKey(config.clientId));
     await tokenStore.save(refreshToken);
@@ -111,8 +111,8 @@ describe("ElectronMainAuthorization Token Logic", () => {
         expires_in: "60000",
       });
 
-    sinon.stub(RefreshTokenStore.prototype, "encryptRefreshToken" as any).returns(Buffer.from(mockTokenResponse.refreshToken!));
-    sinon.stub(RefreshTokenStore.prototype, "decryptRefreshToken" as any).returns(mockTokenResponse.refreshToken);
+    sinon.stub(RefreshTokenStore.prototype, "encryptRefreshToken" as any).returns(Promise.resolve(Buffer.from(mockTokenResponse.refreshToken!)));
+    sinon.stub(RefreshTokenStore.prototype, "decryptRefreshToken" as any).returns(Promise.resolve(mockTokenResponse.refreshToken));
     // Clear token store
     const tokenStore = new RefreshTokenStore(getTokenStoreFileName(config.clientId),getTokenStoreKey(config.clientId));
     await tokenStore.delete();
@@ -162,8 +162,8 @@ describe("ElectronMainAuthorization Token Logic", () => {
       });
 
     const refreshToken = "old refresh token";
-    sinon.stub(RefreshTokenStore.prototype, "encryptRefreshToken" as any).returns(Buffer.from(refreshToken));
-    sinon.stub(RefreshTokenStore.prototype, "decryptRefreshToken" as any).returns(refreshToken);
+    sinon.stub(RefreshTokenStore.prototype, "encryptRefreshToken" as any).returns(Promise.resolve(Buffer.from(refreshToken)));
+    sinon.stub(RefreshTokenStore.prototype, "decryptRefreshToken" as any).returns(Promise.resolve(refreshToken));
     // Load refresh token into token store - use clientId
     const tokenStore = new RefreshTokenStore(getTokenStoreFileName(config.clientId),getTokenStoreKey(config.clientId));
     await tokenStore.save(refreshToken);
@@ -204,8 +204,8 @@ describe("ElectronMainAuthorization Token Logic", () => {
         expires_in: "60000",
       });
 
-    sinon.stub(RefreshTokenStore.prototype, "encryptRefreshToken" as any).returns(Buffer.from(mockTokenResponse.refreshToken!));
-    sinon.stub(RefreshTokenStore.prototype, "decryptRefreshToken" as any).returns(mockTokenResponse.refreshToken);
+    sinon.stub(RefreshTokenStore.prototype, "encryptRefreshToken" as any).returns(Promise.resolve(Buffer.from(mockTokenResponse.refreshToken!)));
+    sinon.stub(RefreshTokenStore.prototype, "decryptRefreshToken" as any).returns(Promise.resolve(mockTokenResponse.refreshToken));
     // Clear token store
     const tokenStore = new RefreshTokenStore(getTokenStoreFileName(config.clientId),getTokenStoreKey(config.clientId));
     await tokenStore.delete();
@@ -257,8 +257,8 @@ describe("ElectronMainAuthorization Token Logic", () => {
     const mockTokenResponse = new TokenResponse(mockTokenResponseJson);
 
     const refreshToken = "old refresh token";
-    sinon.stub(RefreshTokenStore.prototype, "encryptRefreshToken" as any).returns(Buffer.from(refreshToken));
-    const decryptSpy = sinon.stub(RefreshTokenStore.prototype, "decryptRefreshToken" as any).returns(refreshToken);
+    sinon.stub(RefreshTokenStore.prototype, "encryptRefreshToken" as any).returns(Promise.resolve(Buffer.from(refreshToken)));
+    const decryptSpy = sinon.stub(RefreshTokenStore.prototype, "decryptRefreshToken" as any).returns(Promise.resolve(refreshToken));
     // Load refresh token into token store - use clientId
     const tokenStore = new RefreshTokenStore(getTokenStoreFileName(config.clientId),getTokenStoreKey(config.clientId));
     await tokenStore.delete();


### PR DESCRIPTION
Packaged app cannot decrypt not packaged apps token and vice versa. In case tokenStorePath is the same for both types of app, we need to handle decryptRefreshToken failure