### PR TITLE
Add EU cookie consent banner handling to OIDC sign in

### DIFF
--- a/change/@itwin-oidc-signin-tool-72d420f2-1d03-410b-bb97-a96a43c6e8c5.json
+++ b/change/@itwin-oidc-signin-tool-72d420f2-1d03-410b-bb97-a96a43c6e8c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add EU cookie banner handling to OIDC sign-in tool",
+  "packageName": "@itwin/oidc-signin-tool",
+  "email": "jsnaras@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/oidc-signin-tool/src/SignInAutomation.ts
+++ b/packages/oidc-signin-tool/src/SignInAutomation.ts
@@ -249,6 +249,17 @@ async function handleConsentPage<T>(context: AutomatedSignInContext<T>): Promise
     const acceptButton = await page.waitForSelector(
       "xpath=(//button/span[text()='Accept'] | //div[contains(@class, 'ping-buttons')]/a[text()='Accept'])[1]"
     );
+
+    // In EU there is a cookie consent banner covering the accept button, and it must be dismissed first
+    const cookieAcceptButton = await page.waitForSelector(
+      "#onetrust-accept-btn-handler",
+      { timeout: 1000 }
+    );
+
+    if (await cookieAcceptButton.isVisible()) {
+      await cookieAcceptButton.click();
+    }
+
     await acceptButton.click();
   }
 }


### PR DESCRIPTION
In EU the cookie consent banner is obscuring the "Accept" button and must be dismissed before proceeding.t

![image](https://github.com/iTwin/auth-clients/assets/1468929/f4d5aad8-9bbb-4482-98cd-7432703aff57)
