### PR TITLE
Fix EU cookie consent banner selector

### DIFF
--- a/change/@itwin-oidc-signin-tool-00322da7-937f-4373-8299-e57836f62525.json
+++ b/change/@itwin-oidc-signin-tool-00322da7-937f-4373-8299-e57836f62525.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix EU cookie consent banner selector",
+  "packageName": "@itwin/oidc-signin-tool",
+  "email": "jsnaras@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/oidc-signin-tool/src/SignInAutomation.ts
+++ b/packages/oidc-signin-tool/src/SignInAutomation.ts
@@ -251,10 +251,7 @@ async function handleConsentPage<T>(context: AutomatedSignInContext<T>): Promise
     );
 
     // In EU there is a cookie consent banner covering the accept button, and it must be dismissed first
-    const cookieAcceptButton = await page.waitForSelector(
-      "#onetrust-accept-btn-handler",
-      { timeout: 1000 }
-    );
+    const cookieAcceptButton = page.locator("#onetrust-accept-btn-handler");
 
     if (await cookieAcceptButton.isVisible()) {
       await cookieAcceptButton.click();


### PR DESCRIPTION
Previous commit would make the tests time out because it was waiting for an element that does not exist outside of EU.
The `page.locator` is a safe alternative for optional elements.