### PR TITLE
Unify expiry buffer accross electron auth clients

### DIFF
--- a/change/@itwin-electron-authorization-ecff8084-b15a-47e7-8a0f-138ea86b3580.json
+++ b/change/@itwin-electron-authorization-ecff8084-b15a-47e7-8a0f-138ea86b3580.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Unify expiry buffer accross electron auth clients - added ability to set expiryBuffer for ElectronRendererAuthorization, defaulting to 10 min - added defaultExpiryBufferInSeconds to be reused in both electron auth clients - added ElectronRendererAuthorization._tokenRequest to be returned instead of Promise.reject() to short-circuit any recursive use of ElectronRendererAuthorization.getAccessToken",
+  "packageName": "@itwin/electron-authorization",
+  "email": "17436829+GintV@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/electron/src/common/constants.ts
+++ b/packages/electron/src/common/constants.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+/**
+ * Refresh token 10 minutes before real expiration time (by default)
+ */
+export const defaultExpiryBufferInSeconds = 600;

--- a/packages/electron/src/main/Client.ts
+++ b/packages/electron/src/main/Client.ts
@@ -40,6 +40,7 @@ import { ElectronMainAuthorizationRequestHandler } from "./ElectronMainAuthoriza
 import { RefreshTokenStore } from "./TokenStore";
 import { LoopbackWebServer } from "./LoopbackWebServer";
 import * as electron from "electron";
+import { defaultExpiryBufferInSeconds } from "../common/constants";
 import type { IpcChannelNames } from "../common/IpcChannelNames";
 import { getIpcChannelNames } from "../common/IpcChannelNames";
 const loggerCategory = "electron-auth";
@@ -139,7 +140,7 @@ export class ElectronMainAuthorization implements AuthorizationClient {
   private _redirectUris: string[];
   private _clientId: string;
   private _scopes: string;
-  private _expiryBuffer = 60 * 10; // refresh token 10 minutes before real expiration time
+  private _expiryBuffer = defaultExpiryBufferInSeconds;
   private _ipcChannelNames: IpcChannelNames;
   private _ipcSocket?: IpcSocketBackend;
   private _configuration: AuthorizationServiceConfiguration | undefined;


### PR DESCRIPTION
Unify expiry buffer accross electron auth clients
- added ability to set expiryBuffer for ElectronRendererAuthorization, defaulting to 10 min
- added defaultExpiryBufferInSeconds to be reused in both electron auth clients
- added ElectronRendererAuthorization._tokenRequest to be returned instead of Promise.reject() to short-circuit any recursive use of ElectronRendererAuthorization.getAccessToken

Fixes #232 