### PR TITLE
node 20; oidc-ts-client 3.x; remove itwin- 3.x packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '18.12.0'
+          node-version: '20.14.0'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -21,10 +21,10 @@ jobs:
         with:
           version: 8
 
-      - name: Use Node.js 18
+      - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.16.x
+          node-version: 20.14.0
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/.pipelines/integration-test.yaml
+++ b/.pipelines/integration-test.yaml
@@ -30,9 +30,9 @@ jobs:
     persistCredentials: true
 
   - task: NodeTool@0
-    displayName: Use Node 18
+    displayName: Use Node
     inputs:
-      versionSpec: 18.x
+      versionSpec: 20.x
 
   - script: npm install -g pnpm@8
     displayName: Install pnpm

--- a/change/@itwin-browser-authorization-893db361-d94f-4a8f-ac05-b06bdc054246.json
+++ b/change/@itwin-browser-authorization-893db361-d94f-4a8f-ac05-b06bdc054246.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Drop iTwin 3.x support; upgrade to oidc-client-ts 3.0.1 (uses browser's crypto)",
+  "packageName": "@itwin/browser-authorization",
+  "email": "ben-polinsky@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-electron-authorization-726e1390-b89c-483c-85fc-e166e607d4b1.json
+++ b/change/@itwin-electron-authorization-726e1390-b89c-483c-85fc-e166e607d4b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Drop iTwin 3.x support",
+  "packageName": "@itwin/electron-authorization",
+  "email": "ben-polinsky@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-node-cli-authorization-1c125191-4c51-4f93-99f8-ff6ce1284be6.json
+++ b/change/@itwin-node-cli-authorization-1c125191-4c51-4f93-99f8-ff6ce1284be6.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Drop iTwin 3.x support",
+  "packageName": "@itwin/node-cli-authorization",
+  "email": "ben-polinsky@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-oidc-signin-tool-2dabe477-01ee-47b5-8ee3-17d6558d9071.json
+++ b/change/@itwin-oidc-signin-tool-2dabe477-01ee-47b5-8ee3-17d6558d9071.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Drop iTwin 3.x support; Require Node >=20.x; upgrade to oidc-client-ts 3.0.1 (uses browser's crypto)",
+  "packageName": "@itwin/oidc-signin-tool",
+  "email": "ben-polinsky@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -31,17 +31,17 @@
     "directory": "packages/browser"
   },
   "dependencies": {
-    "@itwin/core-common": "^3.7.0 || ^4.0.0",
-    "oidc-client-ts": "^2.4.0"
+    "@itwin/core-common": "^4.0.0",
+    "oidc-client-ts": "^3.0.1"
   },
   "devDependencies": {
-    "@itwin/build-tools": "^4.6.0-dev.27",
-    "@itwin/core-bentley": "^3.7.0",
-    "@itwin/eslint-plugin": "^4.0.2",
+    "@itwin/build-tools": "^4.7.1",
+    "@itwin/core-bentley": "^4.7.1",
+    "@itwin/eslint-plugin": "^4.1.0",
     "@playwright/test": "~1.41.0",
     "@types/chai": "^4.2.22",
     "@types/mocha": "^8.2.3",
-    "@types/node": "^18.11.5",
+    "@types/node": "~20.14.5",
     "@types/sinon": "^10.0.13",
     "buffer": "~6.0.3",
     "chai": "^4.2.2",
@@ -56,6 +56,6 @@
     "typescript": "~5.3.3"
   },
   "peerDependencies": {
-    "@itwin/core-bentley": "^3.3.0 || ^4.0.0"
+    "@itwin/core-bentley": "^4.0.0"
   }
 }

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -41,20 +41,20 @@
     "directory": "packages/electron"
   },
   "dependencies": {
-    "@itwin/core-common": "^3.3.0 || ^4.0.0",
+    "@itwin/core-common": "^4.0.0",
     "@openid/appauth": "^1.3.1",
     "electron-store": "^8.1.0",
     "username": "^5.1.0"
   },
   "devDependencies": {
-    "@itwin/build-tools": "^4.6.0-dev.27",
-    "@itwin/core-bentley": "^3.7.0",
-    "@itwin/eslint-plugin": "^4.0.2",
+    "@itwin/build-tools": "^4.7.1",
+    "@itwin/core-bentley": "^4.7.1",
+    "@itwin/eslint-plugin": "^4.1.0",
     "@playwright/test": "~1.41.0",
     "@types/chai": "^4.2.22",
     "@types/chai-as-promised": "^7.1.1",
     "@types/mocha": "^8.2.3",
-    "@types/node": "~18.18.0",
+    "@types/node": "~20.14.5",
     "@types/sinon": "^10.0.13",
     "chai": "^4.2.2",
     "chai-as-promised": "^7.1.1",
@@ -73,7 +73,7 @@
     "typescript": "~5.3.3"
   },
   "peerDependencies": {
-    "@itwin/core-bentley": "^3.3.0 || ^4.0.0",
+    "@itwin/core-bentley": "^4.0.0",
     "electron": ">=23.0.0 <31.0.0"
   }
 }

--- a/packages/node-cli/package.json
+++ b/packages/node-cli/package.json
@@ -28,21 +28,21 @@
     "directory": "packages/node-cli"
   },
   "dependencies": {
-    "@itwin/core-common": "^3.3.0 || ^4.0.0",
+    "@itwin/core-common": "^4.0.0",
     "@openid/appauth": "^1.3.1",
     "node-persist": "^3.1.3",
     "open": "^8.3.0",
     "username": "^5.1.0"
   },
   "devDependencies": {
-    "@itwin/build-tools": "^4.6.0-dev.27",
-    "@itwin/core-bentley": "^3.7.0",
-    "@itwin/eslint-plugin": "^4.0.2",
+    "@itwin/build-tools": "^4.7.1",
+    "@itwin/core-bentley": "^4.7.1",
+    "@itwin/eslint-plugin": "^4.1.0",
     "@types/chai-as-promised": "^7.1.1",
     "@types/chai": "^4.2.22",
     "@types/mocha": "^8.2.3",
     "@types/node-persist": "^3.1.3",
-    "@types/node": "^18.11.5",
+    "@types/node": "~20.14.5",
     "@types/sinon": "^10.0.16",
     "chai-as-promised": "^7.1.1",
     "chai": "^4.2.2",
@@ -56,7 +56,7 @@
     "typescript": "~5.3.3"
   },
   "peerDependencies": {
-    "@itwin/core-bentley": "^3.3.0 || ^4.0.0"
+    "@itwin/core-bentley": "^4.0.0"
   },
   "eslintConfig": {
     "plugins": [

--- a/packages/oidc-signin-tool/package.json
+++ b/packages/oidc-signin-tool/package.json
@@ -33,24 +33,24 @@
     "url": "http://www.bentley.com"
   },
   "dependencies": {
-    "@itwin/certa": "^3.7.0 || ^4.0.0",
-    "@itwin/core-common": "^3.3.0 || ^4.0.0",
+    "@itwin/certa": "^4.0.0",
+    "@itwin/core-common": "^4.0.0",
     "@itwin/service-authorization": "workspace:^",
     "@playwright/test": "~1.41.0",
     "crypto-browserify": "^3.12.0",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
-    "oidc-client-ts": "^2.4.0"
+    "oidc-client-ts": "^3.0.1"
   },
   "devDependencies": {
-    "@itwin/build-tools": "^4.6.0-dev.27",
-    "@itwin/core-bentley": "^3.7.0",
-    "@itwin/eslint-plugin": "^4.0.2",
+    "@itwin/build-tools": "^4.7.1",
+    "@itwin/core-bentley": "^4.7.1",
+    "@itwin/eslint-plugin": "^4.1.0",
     "@types/chai": "^4.2.22",
     "@types/chai-as-promised": "^7.1.1",
     "@types/jsonwebtoken": "^9.0.1",
     "@types/mocha": "^8.2.3",
-    "@types/node": "^18.11.5",
+    "@types/node": "~20.14.5",
     "@types/sinon": "^10.0.13",
     "chai": "^4.2.2",
     "chai-as-promised": "^7.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,21 +21,21 @@ importers:
   packages/browser:
     dependencies:
       '@itwin/core-common':
-        specifier: ^3.7.0 || ^4.0.0
-        version: 4.0.6(@itwin/core-bentley@3.7.12)(@itwin/core-geometry@4.7.1)
+        specifier: ^4.0.0
+        version: 4.0.6(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1)
       oidc-client-ts:
-        specifier: ^2.4.0
-        version: 2.4.0
+        specifier: ^3.0.1
+        version: 3.0.1
     devDependencies:
       '@itwin/build-tools':
-        specifier: ^4.6.0-dev.27
-        version: 4.6.0-dev.27(@types/node@18.17.1)
+        specifier: ^4.7.1
+        version: 4.7.1(@types/node@20.14.5)
       '@itwin/core-bentley':
-        specifier: ^3.7.0
-        version: 3.7.12
+        specifier: ^4.7.1
+        version: 4.7.1
       '@itwin/eslint-plugin':
-        specifier: ^4.0.2
-        version: 4.0.2(eslint@8.57.0)(typescript@5.3.3)
+        specifier: ^4.1.0
+        version: 4.1.0(eslint@8.57.0)(typescript@5.3.3)
       '@playwright/test':
         specifier: ~1.41.0
         version: 1.41.0
@@ -46,8 +46,8 @@ importers:
         specifier: ^8.2.3
         version: 8.2.3
       '@types/node':
-        specifier: ^18.11.5
-        version: 18.17.1
+        specifier: ~20.14.5
+        version: 20.14.5
       '@types/sinon':
         specifier: ^10.0.13
         version: 10.0.16
@@ -88,8 +88,8 @@ importers:
   packages/electron:
     dependencies:
       '@itwin/core-common':
-        specifier: ^3.3.0 || ^4.0.0
-        version: 4.0.6(@itwin/core-bentley@3.7.12)(@itwin/core-geometry@4.7.1)
+        specifier: ^4.0.0
+        version: 4.0.6(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1)
       '@openid/appauth':
         specifier: ^1.3.1
         version: 1.3.1
@@ -101,14 +101,14 @@ importers:
         version: 5.1.0
     devDependencies:
       '@itwin/build-tools':
-        specifier: ^4.6.0-dev.27
-        version: 4.6.0-dev.27(@types/node@18.18.14)
+        specifier: ^4.7.1
+        version: 4.7.1(@types/node@20.14.5)
       '@itwin/core-bentley':
-        specifier: ^3.7.0
-        version: 3.7.12
+        specifier: ^4.7.1
+        version: 4.7.1
       '@itwin/eslint-plugin':
-        specifier: ^4.0.2
-        version: 4.0.2(eslint@8.57.0)(typescript@5.3.3)
+        specifier: ^4.1.0
+        version: 4.1.0(eslint@8.57.0)(typescript@5.3.3)
       '@playwright/test':
         specifier: ~1.41.0
         version: 1.41.0
@@ -122,8 +122,8 @@ importers:
         specifier: ^8.2.3
         version: 8.2.3
       '@types/node':
-        specifier: ~18.18.0
-        version: 18.18.14
+        specifier: ~20.14.5
+        version: 20.14.5
       '@types/sinon':
         specifier: ^10.0.13
         version: 10.0.16
@@ -176,8 +176,8 @@ importers:
   packages/node-cli:
     dependencies:
       '@itwin/core-common':
-        specifier: ^3.3.0 || ^4.0.0
-        version: 4.0.6(@itwin/core-bentley@3.7.12)(@itwin/core-geometry@4.7.1)
+        specifier: ^4.0.0
+        version: 4.0.6(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1)
       '@openid/appauth':
         specifier: ^1.3.1
         version: 1.3.1
@@ -192,14 +192,14 @@ importers:
         version: 5.1.0
     devDependencies:
       '@itwin/build-tools':
-        specifier: ^4.6.0-dev.27
-        version: 4.6.0-dev.27(@types/node@18.17.1)
+        specifier: ^4.7.1
+        version: 4.7.1(@types/node@20.14.5)
       '@itwin/core-bentley':
-        specifier: ^3.7.0
-        version: 3.7.12
+        specifier: ^4.7.1
+        version: 4.7.1
       '@itwin/eslint-plugin':
-        specifier: ^4.0.2
-        version: 4.0.2(eslint@8.57.0)(typescript@5.3.3)
+        specifier: ^4.1.0
+        version: 4.1.0(eslint@8.57.0)(typescript@5.3.3)
       '@types/chai':
         specifier: ^4.2.22
         version: 4.3.5
@@ -210,8 +210,8 @@ importers:
         specifier: ^8.2.3
         version: 8.2.3
       '@types/node':
-        specifier: ^18.11.5
-        version: 18.17.1
+        specifier: ~20.14.5
+        version: 20.14.5
       '@types/node-persist':
         specifier: ^3.1.3
         version: 3.1.4
@@ -252,11 +252,11 @@ importers:
   packages/oidc-signin-tool:
     dependencies:
       '@itwin/certa':
-        specifier: ^3.7.0 || ^4.0.0
+        specifier: ^4.0.0
         version: 4.7.1
       '@itwin/core-common':
-        specifier: ^3.3.0 || ^4.0.0
-        version: 4.0.6(@itwin/core-bentley@3.7.12)(@itwin/core-geometry@4.7.1)
+        specifier: ^4.0.0
+        version: 4.0.6(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1)
       '@itwin/service-authorization':
         specifier: workspace:^
         version: link:../service
@@ -273,18 +273,18 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       oidc-client-ts:
-        specifier: ^2.4.0
-        version: 2.4.0
+        specifier: ^3.0.1
+        version: 3.0.1
     devDependencies:
       '@itwin/build-tools':
-        specifier: ^4.6.0-dev.27
-        version: 4.6.0-dev.27(@types/node@18.17.1)
+        specifier: ^4.7.1
+        version: 4.7.1(@types/node@20.14.5)
       '@itwin/core-bentley':
-        specifier: ^3.7.0
-        version: 3.7.12
+        specifier: ^4.7.1
+        version: 4.7.1
       '@itwin/eslint-plugin':
-        specifier: ^4.0.2
-        version: 4.0.2(eslint@8.57.0)(typescript@5.3.3)
+        specifier: ^4.1.0
+        version: 4.1.0(eslint@8.57.0)(typescript@5.3.3)
       '@types/chai':
         specifier: ^4.2.22
         version: 4.3.5
@@ -298,8 +298,8 @@ importers:
         specifier: ^8.2.3
         version: 8.2.3
       '@types/node':
-        specifier: ^18.11.5
-        version: 18.17.1
+        specifier: ~20.14.5
+        version: 20.14.5
       '@types/sinon':
         specifier: ^10.0.13
         version: 10.0.16
@@ -731,7 +731,7 @@ packages:
     resolution: {integrity: sha512-EFsmHcT+yRLgZ0cmMzDYRw4LSKmzRx/YpXy854eZKr3y9j8xq2r5TZTLpf85Y1oa8ZIPRHumSWOv2/yKK3qP0Q==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor': 7.40.6
+      '@microsoft/api-extractor': 7.40.6(@types/node@20.14.5)
       chalk: 3.0.0
       cpx2: 3.0.2
       cross-spawn: 7.0.3
@@ -751,11 +751,11 @@ packages:
       - supports-color
     dev: true
 
-  /@itwin/build-tools@4.6.0-dev.27(@types/node@18.17.1):
-    resolution: {integrity: sha512-EFsmHcT+yRLgZ0cmMzDYRw4LSKmzRx/YpXy854eZKr3y9j8xq2r5TZTLpf85Y1oa8ZIPRHumSWOv2/yKK3qP0Q==}
+  /@itwin/build-tools@4.7.1(@types/node@20.14.5):
+    resolution: {integrity: sha512-L6GPnqoNyvDLwE0h44AWNAqCOLFCNsTItIriY9lkfaBW7R6D2HAqPra8K+DcuiJdhBr6UkKrn/r8XVIGFy6sjw==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor': 7.40.6(@types/node@18.17.1)
+      '@microsoft/api-extractor': 7.40.6(@types/node@20.14.5)
       chalk: 3.0.0
       cpx2: 3.0.2
       cross-spawn: 7.0.3
@@ -766,31 +766,7 @@ packages:
       rimraf: 3.0.2
       tree-kill: 1.2.2
       typedoc: 0.25.13(typescript@5.3.3)
-      typedoc-plugin-merge-modules: 4.1.0(typedoc@0.25.13)
-      typescript: 5.3.3
-      wtfnode: 0.9.1
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-    dev: true
-
-  /@itwin/build-tools@4.6.0-dev.27(@types/node@18.18.14):
-    resolution: {integrity: sha512-EFsmHcT+yRLgZ0cmMzDYRw4LSKmzRx/YpXy854eZKr3y9j8xq2r5TZTLpf85Y1oa8ZIPRHumSWOv2/yKK3qP0Q==}
-    hasBin: true
-    dependencies:
-      '@microsoft/api-extractor': 7.40.6(@types/node@18.18.14)
-      chalk: 3.0.0
-      cpx2: 3.0.2
-      cross-spawn: 7.0.3
-      fs-extra: 8.1.0
-      glob: 10.3.12
-      mocha: 10.4.0
-      mocha-junit-reporter: 2.2.1(mocha@10.4.0)
-      rimraf: 3.0.2
-      tree-kill: 1.2.2
-      typedoc: 0.25.13(typescript@5.3.3)
-      typedoc-plugin-merge-modules: 4.1.0(typedoc@0.25.13)
+      typedoc-plugin-merge-modules: 5.1.0(typedoc@0.25.13)
       typescript: 5.3.3
       wtfnode: 0.9.1
       yargs: 17.7.2
@@ -827,7 +803,6 @@ packages:
 
   /@itwin/core-bentley@4.7.1:
     resolution: {integrity: sha512-Us1C1RTsqmT41K0k7r4N/IFxhYCyEt4XgiJNuaYK5g7NCwKlpUedT/KOscC0Dh4saDQ53IK40YFSPp25GfK4YA==}
-    dev: false
 
   /@itwin/core-common@4.0.6(@itwin/core-bentley@3.7.12)(@itwin/core-geometry@4.7.1):
     resolution: {integrity: sha512-1N92kv3bqY/01Mdto/GCKgO5dG6dli9d06lp1KpHTUuwPpWVob1oIF/w5ij+0C4QvHq54SZlCxDfNaC7FH6lKQ==}
@@ -836,6 +811,18 @@ packages:
       '@itwin/core-geometry': ^4.0.6
     dependencies:
       '@itwin/core-bentley': 3.7.12
+      '@itwin/core-geometry': 4.7.1
+      flatbuffers: 1.12.0
+      js-base64: 3.7.5
+    dev: false
+
+  /@itwin/core-common@4.0.6(@itwin/core-bentley@4.7.1)(@itwin/core-geometry@4.7.1):
+    resolution: {integrity: sha512-1N92kv3bqY/01Mdto/GCKgO5dG6dli9d06lp1KpHTUuwPpWVob1oIF/w5ij+0C4QvHq54SZlCxDfNaC7FH6lKQ==}
+    peerDependencies:
+      '@itwin/core-bentley': ^4.0.6
+      '@itwin/core-geometry': ^4.0.6
+    dependencies:
+      '@itwin/core-bentley': 4.7.1
       '@itwin/core-geometry': 4.7.1
       flatbuffers: 1.12.0
       js-base64: 3.7.5
@@ -850,6 +837,33 @@ packages:
 
   /@itwin/eslint-plugin@4.0.2(eslint@8.57.0)(typescript@5.3.3):
     resolution: {integrity: sha512-UDwToOexhFRlS8XQSezvjoRHp8FH9KxfJSb6b1pN2a21g0uhsqxCQDKuOrGwSnJEERIvxMJB0ddH0aYg4dRvJw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: ^3.7.0 || ^4.0.0 || ^5.0.0
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 7.0.2(@typescript-eslint/parser@7.0.2)(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 7.0.2(eslint@8.57.0)(typescript@5.3.3)
+      eslint: 8.57.0
+      eslint-plugin-deprecation: 2.0.0(eslint@8.57.0)(typescript@5.3.3)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.0.2)(eslint@8.57.0)
+      eslint-plugin-jam3: 0.2.3
+      eslint-plugin-jsdoc: 48.2.3(eslint@8.57.0)
+      eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
+      eslint-plugin-prefer-arrow: 1.2.3(eslint@8.57.0)
+      eslint-plugin-react: 7.34.1(eslint@8.57.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
+      typescript: 5.3.3
+      workspace-tools: 0.36.4
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
+  /@itwin/eslint-plugin@4.1.0(eslint@8.57.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-PBl0PXdbGJrgAvYnx59S4d7Ak58luspofyvpnraWMIgC8km6104aF2P9NSa2JAuGjGih3d3YJf5e9tXlmur0fw==}
     engines: {node: ^18.18.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -963,87 +977,27 @@ packages:
     dev: true
     optional: true
 
-  /@microsoft/api-extractor-model@7.28.13:
+  /@microsoft/api-extractor-model@7.28.13(@types/node@20.14.5):
     resolution: {integrity: sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==}
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2(@types/node@18.18.14)
+      '@rushstack/node-core-library': 4.0.2(@types/node@20.14.5)
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor-model@7.28.13(@types/node@18.17.1):
-    resolution: {integrity: sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==}
-    dependencies:
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2(@types/node@18.17.1)
-    transitivePeerDependencies:
-      - '@types/node'
-    dev: true
-
-  /@microsoft/api-extractor-model@7.28.13(@types/node@18.18.14):
-    resolution: {integrity: sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==}
-    dependencies:
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2(@types/node@18.18.14)
-    transitivePeerDependencies:
-      - '@types/node'
-    dev: true
-
-  /@microsoft/api-extractor@7.40.6:
+  /@microsoft/api-extractor@7.40.6(@types/node@20.14.5):
     resolution: {integrity: sha512-9N+XCIQB94Di+ETTzNGLqjgQydslynHou7QPgDhl5gZ+B/Q5hTv5jtqBglTUnTrC0trHdG5/YKN07ehGKlSb5g==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.28.13
+      '@microsoft/api-extractor-model': 7.28.13(@types/node@20.14.5)
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2(@types/node@18.18.14)
+      '@rushstack/node-core-library': 4.0.2(@types/node@20.14.5)
       '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.9.0
-      '@rushstack/ts-command-line': 4.17.3
-      lodash: 4.17.21
-      resolve: 1.22.8
-      semver: 7.5.4
-      source-map: 0.6.1
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - '@types/node'
-    dev: true
-
-  /@microsoft/api-extractor@7.40.6(@types/node@18.17.1):
-    resolution: {integrity: sha512-9N+XCIQB94Di+ETTzNGLqjgQydslynHou7QPgDhl5gZ+B/Q5hTv5jtqBglTUnTrC0trHdG5/YKN07ehGKlSb5g==}
-    hasBin: true
-    dependencies:
-      '@microsoft/api-extractor-model': 7.28.13(@types/node@18.17.1)
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2(@types/node@18.17.1)
-      '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.9.0(@types/node@18.17.1)
-      '@rushstack/ts-command-line': 4.17.3(@types/node@18.17.1)
-      lodash: 4.17.21
-      resolve: 1.22.8
-      semver: 7.5.4
-      source-map: 0.6.1
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - '@types/node'
-    dev: true
-
-  /@microsoft/api-extractor@7.40.6(@types/node@18.18.14):
-    resolution: {integrity: sha512-9N+XCIQB94Di+ETTzNGLqjgQydslynHou7QPgDhl5gZ+B/Q5hTv5jtqBglTUnTrC0trHdG5/YKN07ehGKlSb5g==}
-    hasBin: true
-    dependencies:
-      '@microsoft/api-extractor-model': 7.28.13(@types/node@18.18.14)
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2(@types/node@18.18.14)
-      '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.9.0(@types/node@18.18.14)
-      '@rushstack/ts-command-line': 4.17.3(@types/node@18.18.14)
+      '@rushstack/terminal': 0.9.0(@types/node@20.14.5)
+      '@rushstack/ts-command-line': 4.17.3(@types/node@20.14.5)
       lodash: 4.17.21
       resolve: 1.22.8
       semver: 7.5.4
@@ -2037,7 +1991,7 @@ packages:
     dependencies:
       playwright: 1.41.0
 
-  /@rushstack/node-core-library@4.0.2(@types/node@18.17.1):
+  /@rushstack/node-core-library@4.0.2(@types/node@20.14.5):
     resolution: {integrity: sha512-hyES82QVpkfQMeBMteQUnrhASL/KHPhd7iJ8euduwNJG4mu2GSOKybf0rOEjOm1Wz7CwJEUm9y0yD7jg2C1bfg==}
     peerDependencies:
       '@types/node': '*'
@@ -2045,24 +1999,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 18.17.1
-      fs-extra: 7.0.1
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.8
-      semver: 7.5.4
-      z-schema: 5.0.5
-    dev: true
-
-  /@rushstack/node-core-library@4.0.2(@types/node@18.18.14):
-    resolution: {integrity: sha512-hyES82QVpkfQMeBMteQUnrhASL/KHPhd7iJ8euduwNJG4mu2GSOKybf0rOEjOm1Wz7CwJEUm9y0yD7jg2C1bfg==}
-    peerDependencies:
-      '@types/node': '*'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-    dependencies:
-      '@types/node': 18.18.14
+      '@types/node': 20.14.5
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
@@ -2078,7 +2015,7 @@ packages:
       strip-json-comments: 3.1.1
     dev: true
 
-  /@rushstack/terminal@0.9.0:
+  /@rushstack/terminal@0.9.0(@types/node@20.14.5):
     resolution: {integrity: sha512-49RnIDooriXyqcd7mGyjh9CmjOjf/Vn8PkOQXHa1CS0/RrrynCJLFhRDkswf7gGXZW+6UhROOE8wTmbOrfUTSA==}
     peerDependencies:
       '@types/node': '*'
@@ -2086,62 +2023,15 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': 4.0.2(@types/node@18.18.14)
+      '@rushstack/node-core-library': 4.0.2(@types/node@20.14.5)
+      '@types/node': 20.14.5
       colors: 1.2.5
     dev: true
 
-  /@rushstack/terminal@0.9.0(@types/node@18.17.1):
-    resolution: {integrity: sha512-49RnIDooriXyqcd7mGyjh9CmjOjf/Vn8PkOQXHa1CS0/RrrynCJLFhRDkswf7gGXZW+6UhROOE8wTmbOrfUTSA==}
-    peerDependencies:
-      '@types/node': '*'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-    dependencies:
-      '@rushstack/node-core-library': 4.0.2(@types/node@18.17.1)
-      '@types/node': 18.17.1
-      colors: 1.2.5
-    dev: true
-
-  /@rushstack/terminal@0.9.0(@types/node@18.18.14):
-    resolution: {integrity: sha512-49RnIDooriXyqcd7mGyjh9CmjOjf/Vn8PkOQXHa1CS0/RrrynCJLFhRDkswf7gGXZW+6UhROOE8wTmbOrfUTSA==}
-    peerDependencies:
-      '@types/node': '*'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-    dependencies:
-      '@rushstack/node-core-library': 4.0.2(@types/node@18.18.14)
-      '@types/node': 18.18.14
-      colors: 1.2.5
-    dev: true
-
-  /@rushstack/ts-command-line@4.17.3:
+  /@rushstack/ts-command-line@4.17.3(@types/node@20.14.5):
     resolution: {integrity: sha512-/PtTYW38A8iUviuCmQSccHfmx3uBh4Jm5YRPU2aTgYEgwT2jtg60vAbwnkMYkyaT1AbWpjZM3xq5uHYPURvStw==}
     dependencies:
-      '@rushstack/terminal': 0.9.0
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      string-argv: 0.3.2
-    transitivePeerDependencies:
-      - '@types/node'
-    dev: true
-
-  /@rushstack/ts-command-line@4.17.3(@types/node@18.17.1):
-    resolution: {integrity: sha512-/PtTYW38A8iUviuCmQSccHfmx3uBh4Jm5YRPU2aTgYEgwT2jtg60vAbwnkMYkyaT1AbWpjZM3xq5uHYPURvStw==}
-    dependencies:
-      '@rushstack/terminal': 0.9.0(@types/node@18.17.1)
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      string-argv: 0.3.2
-    transitivePeerDependencies:
-      - '@types/node'
-    dev: true
-
-  /@rushstack/ts-command-line@4.17.3(@types/node@18.18.14):
-    resolution: {integrity: sha512-/PtTYW38A8iUviuCmQSccHfmx3uBh4Jm5YRPU2aTgYEgwT2jtg60vAbwnkMYkyaT1AbWpjZM3xq5uHYPURvStw==}
-    dependencies:
-      '@rushstack/terminal': 0.9.0(@types/node@18.18.14)
+      '@rushstack/terminal': 0.9.0(@types/node@20.14.5)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -2351,7 +2241,7 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 18.18.14
+      '@types/node': 20.14.5
     dev: false
 
   /@types/cacheable-request@6.0.3:
@@ -2359,7 +2249,7 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/keyv': 3.1.4
-      '@types/node': 18.18.14
+      '@types/node': 20.14.5
       '@types/responselike': 1.0.0
     dev: true
 
@@ -2376,13 +2266,13 @@ packages:
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 18.18.14
+      '@types/node': 20.14.5
     dev: false
 
   /@types/express-serve-static-core@4.17.35:
     resolution: {integrity: sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==}
     dependencies:
-      '@types/node': 18.18.14
+      '@types/node': 20.14.5
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
@@ -2421,18 +2311,18 @@ packages:
   /@types/jsonwebtoken@8.5.9:
     resolution: {integrity: sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==}
     dependencies:
-      '@types/node': 18.18.14
+      '@types/node': 20.14.5
 
   /@types/jsonwebtoken@9.0.2:
     resolution: {integrity: sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==}
     dependencies:
-      '@types/node': 18.18.14
+      '@types/node': 20.14.5
     dev: true
 
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 18.18.14
+      '@types/node': 20.14.5
     dev: true
 
   /@types/mime@1.3.2:
@@ -2450,23 +2340,13 @@ packages:
   /@types/node-persist@3.1.4:
     resolution: {integrity: sha512-MXwo/ijhPIIKa5jLxwBfs8wTVZzwO36V/a12TSzsm5hAMFiY9CgSzbFobvQEmQTRu778CIIhJoT59KF2BzSYwg==}
     dependencies:
-      '@types/node': 18.18.14
+      '@types/node': 20.14.5
     dev: true
 
-  /@types/node@18.17.1:
-    resolution: {integrity: sha1-hMMpA786CfeHjDkdMf8I9v59gzU=}
-    dev: true
-
-  /@types/node@18.18.14:
-    resolution: {integrity: sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==}
+  /@types/node@20.14.5:
+    resolution: {integrity: sha512-aoRR+fJkZT2l0aGOJhuA8frnCSoNX6W7U2mpNq63+BxBIj5BQFt8rHy627kijCmm63ijdSdwvGgpUsU6MBsZZA==}
     dependencies:
       undici-types: 5.26.5
-
-  /@types/node@20.11.19:
-    resolution: {integrity: sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==}
-    dependencies:
-      undici-types: 5.26.5
-    dev: true
 
   /@types/qs@6.9.7:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
@@ -2479,7 +2359,7 @@ packages:
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 18.18.14
+      '@types/node': 20.14.5
     dev: true
 
   /@types/semver@7.5.0:
@@ -2490,7 +2370,7 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 18.18.14
+      '@types/node': 20.14.5
     dev: false
 
   /@types/serve-static@1.15.2:
@@ -2498,7 +2378,7 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.1
       '@types/mime': 3.0.1
-      '@types/node': 18.18.14
+      '@types/node': 20.14.5
     dev: false
 
   /@types/sinon@10.0.16:
@@ -2519,7 +2399,7 @@ packages:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 18.18.14
+      '@types/node': 20.14.5
     dev: true
     optional: true
 
@@ -3664,10 +3544,6 @@ packages:
       randomfill: 1.0.4
     dev: false
 
-  /crypto-js@4.2.0:
-    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
-    dev: false
-
   /css-select@4.3.0:
     resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
     dependencies:
@@ -4035,7 +3911,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@electron/get': 2.0.2
-      '@types/node': 20.11.19
+      '@types/node': 20.14.5
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -4206,10 +4082,6 @@ packages:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
     dev: true
 
-  /escalade@3.1.1:
-    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
-    engines: {node: '>=6'}
-
   /escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
     engines: {node: '>=6'}
@@ -4274,7 +4146,7 @@ packages:
     dependencies:
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       eslint: 8.57.0
-      tslib: 2.6.1
+      tslib: 2.6.3
       tsutils: 3.21.0(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -4334,12 +4206,12 @@ packages:
       '@es-joy/jsdoccomment': 0.42.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.5
       escape-string-regexp: 4.0.0
       eslint: 8.57.0
       esquery: 1.5.0
       is-builtin-module: 3.2.1
-      semver: 7.6.0
+      semver: 7.6.2
       spdx-expression-parse: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -5932,8 +5804,9 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
-  /jwt-decode@3.1.2:
-    resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
+  /jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
     dev: false
 
   /keyv@4.5.3:
@@ -6695,12 +6568,11 @@ packages:
       es-object-atoms: 1.0.0
     dev: true
 
-  /oidc-client-ts@2.4.0:
-    resolution: {integrity: sha512-WijhkTrlXK2VvgGoakWJiBdfIsVGz6CFzgjNNqZU1hPKV2kyeEaJgLs7RwuiSp2WhLfWBQuLvr2SxVlZnk3N1w==}
-    engines: {node: '>=12.13.0'}
+  /oidc-client-ts@3.0.1:
+    resolution: {integrity: sha512-xX8unZNtmtw3sOz4FPSqDhkLFnxCDsdo2qhFEH2opgWnF/iXMFoYdBQzkwCxAZVgt3FT3DnuBY3k80EZHT0RYg==}
+    engines: {node: '>=18'}
     dependencies:
-      crypto-js: 4.2.0
-      jwt-decode: 3.1.2
+      jwt-decode: 4.0.0
     dev: false
 
   /on-finished@2.4.1:
@@ -7926,10 +7798,6 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tslib@2.6.1:
-    resolution: {integrity: sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==}
-    dev: true
-
   /tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
     dev: true
@@ -8040,6 +7908,14 @@ packages:
     resolution: {integrity: sha512-0Qax5eSaiP86zX9LlQQWANjtgkMfSHt6/LRDsWXfK45Ifc3lrgjZG4ieE87BMi3p12r/F0qW9sHQRB18tIs0fg==}
     peerDependencies:
       typedoc: 0.23.x || 0.24.x
+    dependencies:
+      typedoc: 0.25.13(typescript@5.3.3)
+    dev: true
+
+  /typedoc-plugin-merge-modules@5.1.0(typedoc@0.25.13):
+    resolution: {integrity: sha512-jXH27L/wlxFjErgBXleh3opVgjVTXFEuBo68Yfl18S9Oh/IqxK6NV94jlEJ9hl4TXc9Zm2l7Rfk41CEkcCyvFQ==}
+    peerDependencies:
+      typedoc: 0.24.x || 0.25.x
     dependencies:
       typedoc: 0.25.13(typescript@5.3.3)
     dev: true
@@ -8379,7 +8255,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       cliui: 8.0.1
-      escalade: 3.1.1
+      escalade: 3.1.2
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3


### PR DESCRIPTION
- Update ci and node types to 20.x. Not only is 20.x LTS, but it is required for oidc-ts-client@3.x which relies on the browser's crypto. Node>18.x automatically adds `crypto` to `globalThis`. 
- update oidc-ts-client to 3.x
- remove support for itwin 3.x packages


closes: #246 