### PR TITLE
Add missing support for subpaths

### DIFF
--- a/change/@itwin-electron-authorization-c23454e0-2ce1-4ca5-b18b-513b6969c59a.json
+++ b/change/@itwin-electron-authorization-c23454e0-2ce1-4ca5-b18b-513b6969c59a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add missing CJS and ESM support for subpath imports",
+  "packageName": "@itwin/electron-authorization",
+  "email": "50554904+hl662@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -5,11 +5,13 @@
   "exports": {
     "./Main": {
       "types": "./lib/cjs/ElectronMain.d.ts",
+      "import": "./lib/esm/ElectronMain.js",
       "require": "./lib/cjs/ElectronMain.js"
     },
     "./Renderer": {
       "types": "./lib/esm/ElectronRenderer.d.ts",
-      "import": "./lib/esm/ElectronRenderer.js"
+      "import": "./lib/esm/ElectronRenderer.js",
+      "require": "./lib/cjs/ElectronRenderer.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
When using `export` and subpaths, to fully support CJS and ESM, we need each subpath to contain `import` and `require`.

Previously, `./Renderer` didn't support CJS, because it didn't have a `require` field. This would cause problems in packages, like `itwinjs/core` `core-full-stack-tests`, that consumes both Main and Renderer, but outputs CJS files. At build time, this wouldn't be caught, but during runtime, it would throw a `PACKAGE_PATH_NOT_SUPPORTED`, because when it tried to use the Renderer subpath, it couldn't find a valid CJS path.

Vice versa, with `./Main` in ESM outputted files.

This issue is fixed by adding both `import` and `require` and their valid values to each subpath.

