### PR TITLE
Fix method name in README.md

### DIFF
--- a/change/@itwin-browser-authorization-3f00ac2a-a4ab-4726-920a-e86d734aa609.json
+++ b/change/@itwin-browser-authorization-3f00ac2a-a4ab-4726-920a-e86d734aa609.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix method name in README.md",
+  "packageName": "@itwin/browser-authorization",
+  "email": "GytisCepk@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -35,7 +35,7 @@ await client.signInRedirect();
 Instead of a redirect, you may want to trigger a pop up to handle the sign in process:
 
 ```typescript
-await client.signinPopup();
+await client.signInPopup();
 ```
 
 After the user signs in, they will be redirected to the redirect url specified in your oidc configuration (developer.bentley.com)

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -36,7 +36,7 @@ await client.signInRedirect();
 Instead of a redirect, you may want to trigger a pop up to handle the sign in process:
 
 ```typescript
-await client.signinPopup();
+await client.signInPopup();
 ```
 
 After the user signs in, they will be redirected to the redirect url specified in your oidc configuration (developer.bentley.com)


### PR DESCRIPTION
Spotted during workshop.

Side note: words "sign in" are not consistently spelled in methods' names (e.g. sign**i**n in `handleSigninCallback` and sign**I**n in `signInRedirect`). Not worth doing major version for, however.