### PR TITLE
Remove Discouraged 'networkidle' Calls

### DIFF
--- a/change/@itwin-oidc-signin-tool-3c9c072f-ae0a-4ffc-a7fc-06d6c9871fe3.json
+++ b/change/@itwin-oidc-signin-tool-3c9c072f-ae0a-4ffc-a7fc-06d6c9871fe3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove discouraged 'networkidle'",
+  "packageName": "@itwin/oidc-signin-tool",
+  "email": "108895074+MichaelSwigerAtBentley@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/oidc-signin-tool/src/SignInAutomation.ts
+++ b/packages/oidc-signin-tool/src/SignInAutomation.ts
@@ -111,7 +111,6 @@ export async function automatedSignOut<T>(
 }
 
 async function handleErrorPage<T>({ page }: AutomatedContextBase<T>): Promise<void> {
-  await page.waitForLoadState("networkidle");
   const pageTitle = await page.title();
   let errMsgText;
 
@@ -166,7 +165,6 @@ async function handlePingLoginPage<T>(context: AutomatedSignInContext<T>): Promi
   allow = page.locator(testSelectors.pingAllowSubmit);
   await allow.click();
 
-  await page.waitForLoadState("networkidle");
   const error = page.getByText(
     "We didn't recognize the email address or password you entered. Please try again.",
   );
@@ -187,7 +185,6 @@ async function handlePingLoginPage<T>(context: AutomatedSignInContext<T>): Promi
 async function handleFederatedSignin<T>(context: AutomatedSignInContext<T>): Promise<void> {
   const { page } = context;
 
-  await page.waitForLoadState("networkidle");
   if (-1 === page.url().indexOf("microsoftonline"))
     return;
 
@@ -270,7 +267,6 @@ async function checkSelectorExists(
 }
 
 async function checkErrorOnPage(page: Page, selector: string): Promise<void> {
-  await page.waitForLoadState("networkidle");
   const errMsgElement = await page.$(selector);
   if (errMsgElement) {
     const errMsgText = await errMsgElement.textContent();

--- a/packages/oidc-signin-tool/src/SignInAutomation.ts
+++ b/packages/oidc-signin-tool/src/SignInAutomation.ts
@@ -188,8 +188,11 @@ async function handleFederatedSignin<T>(context: AutomatedSignInContext<T>): Pro
   if (-1 === page.url().indexOf("microsoftonline"))
     return;
 
-  // await page.waitForSelector(testSelectors.msUserNameField); || waitForSelector(testSelectors.fedPassword)
-  await page.waitForLoadState("domcontentloaded");
+  // Wait for either msUserNameField or fedPassword to be visible
+  const msUserNameFieldPromise = page.waitForSelector(testSelectors.msUserNameField, { state: "visible" });
+  const fedPasswordPromise = page.waitForSelector(testSelectors.fedPassword, { state: "visible" });
+  await Promise.race([msUserNameFieldPromise, fedPasswordPromise]);
+
   if (await checkSelectorExists(page, testSelectors.msUserNameField)) {
     await page.locator(testSelectors.msUserNameField).fill(context.user.email);
     const msSubmit = await page.waitForSelector(testSelectors.msSubmit);

--- a/packages/oidc-signin-tool/src/SignInAutomation.ts
+++ b/packages/oidc-signin-tool/src/SignInAutomation.ts
@@ -188,7 +188,8 @@ async function handleFederatedSignin<T>(context: AutomatedSignInContext<T>): Pro
   if (-1 === page.url().indexOf("microsoftonline"))
     return;
 
-  await page.waitForLoadState("networkidle");
+  // await page.waitForSelector(testSelectors.msUserNameField); || waitForSelector(testSelectors.fedPassword)
+  await page.waitForLoadState("domcontentloaded");
   if (await checkSelectorExists(page, testSelectors.msUserNameField)) {
     await page.locator(testSelectors.msUserNameField).fill(context.user.email);
     const msSubmit = await page.waitForSelector(testSelectors.msSubmit);

--- a/packages/oidc-signin-tool/src/SignInAutomation.ts
+++ b/packages/oidc-signin-tool/src/SignInAutomation.ts
@@ -188,6 +188,7 @@ async function handleFederatedSignin<T>(context: AutomatedSignInContext<T>): Pro
   if (-1 === page.url().indexOf("microsoftonline"))
     return;
 
+  await page.waitForLoadState("load");
   if (await checkSelectorExists(page, testSelectors.msUserNameField)) {
     await page.locator(testSelectors.msUserNameField).fill(context.user.email);
     const msSubmit = await page.waitForSelector(testSelectors.msSubmit);

--- a/packages/oidc-signin-tool/src/SignInAutomation.ts
+++ b/packages/oidc-signin-tool/src/SignInAutomation.ts
@@ -188,7 +188,7 @@ async function handleFederatedSignin<T>(context: AutomatedSignInContext<T>): Pro
   if (-1 === page.url().indexOf("microsoftonline"))
     return;
 
-  await page.waitForLoadState("load");
+  await page.waitForLoadState("networkidle");
   if (await checkSelectorExists(page, testSelectors.msUserNameField)) {
     await page.locator(testSelectors.msUserNameField).fill(context.user.email);
     const msSubmit = await page.waitForSelector(testSelectors.msSubmit);


### PR DESCRIPTION
Removes 4 waitForLoadState('networkidle') calls in SignInAutomation.ts as outlined in issue https://github.com/iTwin/auth-clients/issues/262

I was unable to get integration tests running locally (token requests failed with invalid client Id), even with the same configs and @ben-polinsky's help. Opening a PR for now to try integration tests through the pipeline.