### PR TITLE
Reintroduce actions/setup-node and make sure registry-url is provided for npm publish authentication

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,9 +28,9 @@ jobs:
           git config --local user.name imodeljs-admin
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/create-github-release.yaml
+++ b/.github/workflows/create-github-release.yaml
@@ -17,6 +17,11 @@ jobs:
           ref: ${{ github.ref }} # checkouts the branch that triggered the workflow
           fetch-depth: 0
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 

--- a/.github/workflows/publish-packages.yaml
+++ b/.github/workflows/publish-packages.yaml
@@ -13,6 +13,12 @@ jobs:
         with:
           token: ${{ secrets.IMJS_ADMIN_GH_TOKEN }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          registry-url: https://registry.npmjs.org/
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "change": "beachball change",
     "check": "beachball check",
     "version-bump": "beachball bump",
-    "publish-packages": "beachball publish --access public"
+    "publish-packages": "beachball publish --access public --no-push --no-publish"
   },
   "keywords": [
     "Bentley",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "change": "beachball change",
     "check": "beachball check",
     "version-bump": "beachball bump",
-    "publish-packages": "beachball publish --access public --no-push --no-publish"
+    "publish-packages": "beachball publish --access public"
   },
   "keywords": [
     "Bentley",


### PR DESCRIPTION
From this [SO](https://stackoverflow.com/questions/75766122/whats-the-difference-between-node-auth-token-and-npm-auth-token#comment138206931_77539464) post, we can derive that we need to specify the `registry-url` when setting up node. That way, `NODE_AUTH_TOKEN` would be used and added to `.npmrc` during our CI runs.

Also, we have to re-add `actions/setup-node` to our yaml scripts, because `pnpm/action-setup` [does not replace it](https://github.com/pnpm/action-setup?tab=readme-ov-file#notes). Also bumped the setup-node actions in `ci.yaml` to use v4 alongside.


Dry Run success: https://github.com/iTwin/auth-clients/actions/runs/13378305641/job/37362067098
