### PR TITLE
Exposed a few methods to derived class to support other client

### DIFF
--- a/change/@itwin-electron-authorization-7f7c86fe-7b62-4e7d-848f-2d36792f35c6.json
+++ b/change/@itwin-electron-authorization-7f7c86fe-7b62-4e7d-848f-2d36792f35c6.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Exposed a few methods to the derived class to support connection client.",
+  "comment": "Exposed a few methods to the derived class to support other client.",
   "packageName": "@itwin/electron-authorization",
   "email": "3654177+abeesh@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@itwin-electron-authorization-7f7c86fe-7b62-4e7d-848f-2d36792f35c6.json
+++ b/change/@itwin-electron-authorization-7f7c86fe-7b62-4e7d-848f-2d36792f35c6.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Exposed a few methods to the derived class to support other client.",
+  "comment": "Exposed a few methods to the derived class to support other clients",
   "packageName": "@itwin/electron-authorization",
   "email": "3654177+abeesh@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@itwin-electron-authorization-7f7c86fe-7b62-4e7d-848f-2d36792f35c6.json
+++ b/change/@itwin-electron-authorization-7f7c86fe-7b62-4e7d-848f-2d36792f35c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Exposed a few methods to the derived class to support connection client.",
+  "packageName": "@itwin/electron-authorization",
+  "email": "3654177+abeesh@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/electron/src/main/Client.ts
+++ b/packages/electron/src/main/Client.ts
@@ -281,7 +281,7 @@ export class ElectronMainAuthorization implements AuthorizationClient {
     return this._accessToken;
   }
 
-  private setAccessToken(token: AccessToken) {
+  protected setAccessToken(token: AccessToken) {
     if (token === this._accessToken)
       return;
 
@@ -301,7 +301,7 @@ export class ElectronMainAuthorization implements AuthorizationClient {
   /** Loads the access token from the store, and refreshes it if necessary and possible
    * @return AccessToken if it's possible to get a valid access token, and undefined otherwise.
    */
-  private async loadAccessToken(): Promise<AccessToken> {
+  protected async loadAccessToken(): Promise<AccessToken> {
     const refreshToken = await this._refreshTokenStore.load(this._scopes);
 
     if (!refreshToken)
@@ -522,7 +522,7 @@ export class ElectronMainAuthorization implements AuthorizationClient {
       await electron.shell.openExternal(this._configuration.endSessionEndpoint);
   }
 
-  private async processTokenResponse(
+  protected async processTokenResponse(
     tokenResponse: TokenResponse,
   ): Promise<AccessToken> {
     this._refreshToken = tokenResponse.refreshToken;
@@ -540,7 +540,7 @@ export class ElectronMainAuthorization implements AuthorizationClient {
     return bearerToken;
   }
 
-  private async clearTokenCache() {
+  protected async clearTokenCache() {
     this._refreshToken = undefined;
     this._expiresAt = undefined;
 


### PR DESCRIPTION
In the case of a connection client authentication workflow, we get the code from the connection client directly instead of a loop back webserver. So ,I need to expose a few methods so that I can override the signin method.