### PR TITLE
Add missing '@itwin/core-geometry' dependency to service package

### DIFF
--- a/change/@itwin-service-authorization-25a3c167-db19-4a67-97fd-77e7a9d5d396.json
+++ b/change/@itwin-service-authorization-25a3c167-db19-4a67-97fd-77e7a9d5d396.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add '@itwin/core-geometry' as a peer dep to service package",
+  "packageName": "@itwin/service-authorization",
+  "email": "GytisCepk@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-service-authorization-25a3c167-db19-4a67-97fd-77e7a9d5d396.json
+++ b/change/@itwin-service-authorization-25a3c167-db19-4a67-97fd-77e7a9d5d396.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Add '@itwin/core-geometry' as a peer dep to service package",
+  "comment": "Add '@itwin/core-geometry' as a dependency",
   "packageName": "@itwin/service-authorization",
   "email": "GytisCepk@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@itwin/core-common": "^3.3.0 || ^4.0.0",
+    "@itwin/core-geometry": "^3.3.0 || ^4.0.0",
     "got": "^12.6.1",
     "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^2.0.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,6 +318,9 @@ importers:
       '@itwin/core-common':
         specifier: ^3.3.0 || ^4.0.0
         version: 4.0.6(@itwin/core-bentley@3.7.12)(@itwin/core-geometry@4.7.1)
+      '@itwin/core-geometry':
+        specifier: ^3.3.0 || ^4.0.0
+        version: 4.7.1
       got:
         specifier: ^12.6.1
         version: 12.6.1


### PR DESCRIPTION
Because of missing peer dependency, users may see:
```
 WARN  Issues with peer dependencies found
 ...
  └─┬ @itwin/service-authorization 1.2.2
    └─┬ @itwin/core-common 4.2.1
      └── ✕ missing peer @itwin/core-geometry@^4.2.1
Peer dependencies that should be installed:
  @itwin/core-geometry@^4.2.1
```