### PR TITLE
Add support for Electron 34, 35 and 36

### DIFF
--- a/change/@itwin-electron-authorization-bd9ae83c-ff35-4039-9107-b06f2d1040ef.json
+++ b/change/@itwin-electron-authorization-bd9ae83c-ff35-4039-9107-b06f2d1040ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add support for Electron 34, 35 and 36",
+  "packageName": "@itwin/electron-authorization",
+  "email": "GytisCepk@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -62,7 +62,7 @@
     "chai-as-promised": "^7.1.1",
     "cpx2": "^5.0.0",
     "dotenv": "~16.0.3",
-    "electron": "^33.0.0",
+    "electron": "^36.3.2",
     "eslint": "^8.56.0",
     "mocha": "^10.2.0",
     "nyc": "^17.0.0",
@@ -74,6 +74,6 @@
   },
   "peerDependencies": {
     "@itwin/core-bentley": "^3.3.0 || ^4.0.0",
-    "electron": ">=23.0.0 <34.0.0"
+    "electron": ">=23.0.0 <37.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,8 +134,8 @@ importers:
         specifier: ~16.0.3
         version: 16.0.3
       electron:
-        specifier: ^33.0.0
-        version: 33.0.1
+        specifier: ^36.3.2
+        version: 36.3.2
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -1008,8 +1008,8 @@ packages:
   '@types/node@18.18.14':
     resolution: {integrity: sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==}
 
-  '@types/node@20.11.19':
-    resolution: {integrity: sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==}
+  '@types/node@22.15.24':
+    resolution: {integrity: sha512-w9CZGm9RDjzTh/D+hFwlBJ3ziUaVw7oufKA3vOFSOZlzmW9AkZnfjPb+DLnrV6qtgL/LNmP0/2zBNCFHL3F0ng==}
 
   '@types/qs@6.9.7':
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
@@ -1623,10 +1623,6 @@ packages:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
 
-  define-properties@1.2.0:
-    resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
-    engines: {node: '>= 0.4'}
-
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
@@ -1713,8 +1709,8 @@ packages:
   electron-to-chromium@1.4.805:
     resolution: {integrity: sha512-8W4UJwX/w9T0QSzINJckTKG6CYpAUTqsaWcWIsdud3I1FYJcMgW9QqT1/4CBff/pP/TihWh13OmiyY8neto6vw==}
 
-  electron@33.0.1:
-    resolution: {integrity: sha512-PipPnWH4gvf7o+P8jlKQZGgPfb5eHcLgTrnKkFzb98MXhyPjVJYCR7YWqcawZ8IfyJCut8vMxLuBFLT1Ag8TSQ==}
+  electron@36.3.2:
+    resolution: {integrity: sha512-v0/j7n22CL3OYv9BIhq6JJz2+e1HmY9H4bjTk8/WzVT9JwVX/T/21YNdR7xuQ6XDSEo9gP5JnqmjOamE+CUY8Q==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -3692,6 +3688,9 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -4693,9 +4692,9 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@20.11.19':
+  '@types/node@22.15.24':
     dependencies:
-      undici-types: 5.26.5
+      undici-types: 6.21.0
 
   '@types/qs@6.9.7': {}
 
@@ -5420,11 +5419,6 @@ snapshots:
 
   define-lazy-prop@2.0.0: {}
 
-  define-properties@1.2.0:
-    dependencies:
-      has-property-descriptors: 1.0.2
-      object-keys: 1.1.1
-
   define-properties@1.2.1:
     dependencies:
       define-data-property: 1.1.4
@@ -5495,10 +5489,10 @@ snapshots:
 
   electron-to-chromium@1.4.805: {}
 
-  electron@33.0.1:
+  electron@36.3.2:
     dependencies:
       '@electron/get': 2.0.2
-      '@types/node': 20.11.19
+      '@types/node': 22.15.24
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -6211,7 +6205,7 @@ snapshots:
 
   globalthis@1.0.3:
     dependencies:
-      define-properties: 1.2.0
+      define-properties: 1.2.1
 
   globby@11.1.0:
     dependencies:
@@ -7742,6 +7736,8 @@ snapshots:
       which-boxed-primitive: 1.0.2
 
   undici-types@5.26.5: {}
+
+  undici-types@6.21.0: {}
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
Even though auth packages do not support iTwin.js 5.0 rc officially, there are products which try to use it (e.g. https://github.com/iTwin/viewer/pull/366). This is a problem since there is no overlap in supported Electron versions between 4.x and 5.0 rc.

Once auth packages drop iTwin.js 4.x, support, we should drop support for old Electron versions as well.