### PR TITLE
integration tests - update ubuntu pkgs

### DIFF
--- a/.pipelines/integration-test.yaml
+++ b/.pipelines/integration-test.yaml
@@ -87,6 +87,7 @@ jobs:
     displayName: Build packages
 
   - script: |
+          sudo apt-get update -y
           sudo apt-get install -y libsecret-1-dev
           sudo apt-get install -y dbus-x11
           sudo apt-get install -y gnome-keyring


### PR DESCRIPTION
Following #303, fix ubuntu integration tests ci 