### PR TITLE
move testing deps to devDependencies

### DIFF
--- a/packages/oidc-signin-tool/package.json
+++ b/packages/oidc-signin-tool/package.json
@@ -33,18 +33,18 @@
     "url": "http://www.bentley.com"
   },
   "dependencies": {
-    "@itwin/certa": "^5.0.0",
     "@itwin/service-authorization": "workspace:^",
-    "@playwright/test": "~1.48.2",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
     "oidc-client-ts": "^3.3.0"
   },
   "devDependencies": {
     "@itwin/build-tools": "^5.0.0",
+    "@itwin/certa": "^5.0.0",
     "@itwin/core-bentley": "^5.0.0",
     "@itwin/core-common": "^5.0.0",
     "@itwin/eslint-plugin": "^4.1.1",
+    "@playwright/test": "~1.48.2",
     "@types/chai": "^4.3.20",
     "@types/chai-as-promised": "^7.1.8",
     "@types/jsonwebtoken": "^9.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,15 +239,9 @@ importers:
 
   packages/oidc-signin-tool:
     dependencies:
-      '@itwin/certa':
-        specifier: ^5.0.0
-        version: 5.0.3
       '@itwin/service-authorization':
         specifier: workspace:^
         version: link:../service
-      '@playwright/test':
-        specifier: ~1.48.2
-        version: 1.48.2
       dotenv:
         specifier: ^10.0.0
         version: 10.0.0
@@ -261,6 +255,9 @@ importers:
       '@itwin/build-tools':
         specifier: ^5.0.0
         version: 5.0.3(@types/node@20.19.1)
+      '@itwin/certa':
+        specifier: ^5.0.0
+        version: 5.0.3
       '@itwin/core-bentley':
         specifier: ^5.0.0
         version: 5.0.3
@@ -270,6 +267,9 @@ importers:
       '@itwin/eslint-plugin':
         specifier: ^4.1.1
         version: 4.1.1(eslint@8.57.1)(typescript@5.6.3)
+      '@playwright/test':
+        specifier: ~1.48.2
+        version: 1.48.2
       '@types/chai':
         specifier: ^4.3.20
         version: 4.3.20


### PR DESCRIPTION
Not sure if there was a reason to keep in dependencies. The problem that iTwin Studio ran into was when installing deps for a production build the certa postinstall was executing, which attempts to download and install chromium from playwright. This is quite costly