### PR TITLE
Bump `@playwright/test` version to `~1.56.1`

### DIFF
--- a/change/@itwin-browser-authorization-e6c9f4b9-131e-438c-b867-00247e3f8f63.json
+++ b/change/@itwin-browser-authorization-e6c9f4b9-131e-438c-b867-00247e3f8f63.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump `@playwright/test` dev dependency version to `~1.56.1`.",
+  "packageName": "@itwin/browser-authorization",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@itwin-electron-authorization-55bd38d7-a2b1-4450-9bb3-8435be667850.json
+++ b/change/@itwin-electron-authorization-55bd38d7-a2b1-4450-9bb3-8435be667850.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump `@playwright/test` dev dependency version to `~1.56.1`.",
+  "packageName": "@itwin/electron-authorization",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@itwin-oidc-signin-tool-c8b2d27e-60ce-4c1b-9456-9c7d6b00ba95.json
+++ b/change/@itwin-oidc-signin-tool-c8b2d27e-60ce-4c1b-9456-9c7d6b00ba95.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump `@playwright/test` dependency version to `~1.56.1`.",
+  "packageName": "@itwin/oidc-signin-tool",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -39,7 +39,7 @@
     "@itwin/core-bentley": "^5.0.0",
     "@itwin/core-common": "^5.0.0",
     "@itwin/eslint-plugin": "^4.1.1",
-    "@playwright/test": "~1.48.2",
+    "@playwright/test": "~1.56.1",
     "@types/chai": "^4.3.20",
     "@types/mocha": "^8.2.3",
     "@types/node": "^20.19.1",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -53,7 +53,7 @@
     "@itwin/core-bentley": "^5.0.0",
     "@itwin/core-common": "^5.0.0",
     "@itwin/eslint-plugin": "^4.1.1",
-    "@playwright/test": "~1.48.2",
+    "@playwright/test": "~1.56.1",
     "@types/chai": "4.3.14",
     "@types/chai-as-promised": "^7.1.8",
     "@types/mocha": "^8.2.3",

--- a/packages/oidc-signin-tool/package.json
+++ b/packages/oidc-signin-tool/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@itwin/certa": "^5.0.0",
     "@itwin/service-authorization": "workspace:^",
-    "@playwright/test": "~1.48.2",
+    "@playwright/test": "~1.56.1",
     "dotenv": "^10.0.0",
     "dotenv-expand": "^5.1.0",
     "oidc-client-ts": "^3.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1(eslint@8.57.1)(typescript@5.6.3)
       '@playwright/test':
-        specifier: ~1.48.2
-        version: 1.48.2
+        specifier: ~1.56.1
+        version: 1.56.1
       '@types/chai':
         specifier: ^4.3.20
         version: 4.3.20
@@ -104,8 +104,8 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1(eslint@8.57.1)(typescript@5.6.3)
       '@playwright/test':
-        specifier: ~1.48.2
-        version: 1.48.2
+        specifier: ~1.56.1
+        version: 1.56.1
       '@types/chai':
         specifier: 4.3.14
         version: 4.3.14
@@ -246,8 +246,8 @@ importers:
         specifier: workspace:^
         version: link:../service
       '@playwright/test':
-        specifier: ~1.48.2
-        version: 1.48.2
+        specifier: ~1.56.1
+        version: 1.56.1
       dotenv:
         specifier: ^10.0.0
         version: 10.0.0
@@ -760,8 +760,8 @@ packages:
     resolution: {integrity: sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.48.2':
-    resolution: {integrity: sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==}
+  '@playwright/test@1.56.1':
+    resolution: {integrity: sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3329,8 +3329,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright-core@1.48.2:
-    resolution: {integrity: sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==}
+  playwright-core@1.56.1:
+    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3339,8 +3339,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.48.2:
-    resolution: {integrity: sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==}
+  playwright@1.56.1:
+    resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4652,9 +4652,9 @@ snapshots:
 
   '@pkgr/core@0.1.2': {}
 
-  '@playwright/test@1.48.2':
+  '@playwright/test@1.56.1':
     dependencies:
-      playwright: 1.48.2
+      playwright: 1.56.1
 
   '@rollup/rollup-android-arm-eabi@4.43.0':
     optional: true
@@ -7664,7 +7664,7 @@ snapshots:
 
   playwright-core@1.47.2: {}
 
-  playwright-core@1.48.2: {}
+  playwright-core@1.56.1: {}
 
   playwright@1.47.2:
     dependencies:
@@ -7672,9 +7672,9 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  playwright@1.48.2:
+  playwright@1.56.1:
     dependencies:
-      playwright-core: 1.48.2
+      playwright-core: 1.56.1
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
A step towards fixing https://github.com/iTwin/auth-clients/security/dependabot/58, but there's an `@itwin/certa` dependency in this repo that also uses an old `playwright` version. Because of cross-repo deps we need to fix `@itwin/oidc-signin-tool` first, then consume it in core repo, only then we can bump certa here.