### PR TITLE
update silent renew example + silent renew test

### DIFF
--- a/change/@itwin-browser-authorization-5e1d052e-b062-478c-9c22-ea2b5f3b3da5.json
+++ b/change/@itwin-browser-authorization-5e1d052e-b062-478c-9c22-ea2b5f3b3da5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add silent renew test",
+  "packageName": "@itwin/browser-authorization",
+  "email": "ben-polinsky@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@itwin-browser-authorization-5e1d052e-b062-478c-9c22-ea2b5f3b3da5.json
+++ b/change/@itwin-browser-authorization-5e1d052e-b062-478c-9c22-ea2b5f3b3da5.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "add silent renew test",
+  "comment": "",
   "packageName": "@itwin/browser-authorization",
   "email": "ben-polinsky@users.noreply.github.com",
   "dependentChangeType": "none"

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -50,12 +50,12 @@ to complete the process. Once back on your initial page, the call to `client.sig
 If the callback occurs on a page where the configured `client` is not available, you can use the static method to complete the process:
 
 ```typescript
-await BrowserAuthorizationClient.handleSigninCallback();
+await BrowserAuthorizationClient.handleSignInCallback();
 
 // This library defaults to localStorage for storing state.
 // To use sessionStorage (or another Storage object), you can pass it as an argument.
 // If overriding the default localStorage, also set the stateStore via client.setAdvancedSettings({stateStore: yourStore})
-await BrowserAuthorizationClient.handleSigninCallback(window.sessionStorage);
+await BrowserAuthorizationClient.handleSignInCallback(window.sessionStorage);
 ```
 
 This will pull the client configuration from localStorage, using the state nonce provided by OIDC to select the proper configuration.
@@ -63,6 +63,8 @@ This will pull the client configuration from localStorage, using the state nonce
 Other notable methods:
 `client.signOutRedirect()` - starts the signout flow via redirect
 `client.signOutPopup()` - starts the signout flow via popup.
+`client.forceSilentRenew()` - forces a silent token renewal even when a cached user already exists locally.
+`client.accessTokenExpiresAt` - returns the current access token expiration time, if known.
 `client.setAdvancedSettings(userManagerSettings)` - Allows for advanced options to be supplied to the underlying UserManager.
 
 ## Silent Redirect URI (Required for Automatic Token Renewal)

--- a/packages/browser/src/Client.ts
+++ b/packages/browser/src/Client.ts
@@ -74,6 +74,10 @@ export class BrowserAuthorizationClient implements AuthorizationClient {
     return !!this._accessToken;
   }
 
+  public get accessTokenExpiresAt(): Date | undefined {
+    return this._expiresAt ? new Date(this._expiresAt) : undefined;
+  }
+
   public get authorityUrl(): string {
     return this._advancedSettings?.authority ?? this._basicSettings.authority;
   }
@@ -210,6 +214,16 @@ export class BrowserAuthorizationClient implements AuthorizationClient {
   }
 
   /**
+   * Forces a silent token renewal against the authorization provider even when a cached user exists locally.
+   * @throws [Error] If the silent sign in fails
+   */
+  public async forceSilentRenew(): Promise<void> {
+    const user = await this.performSilentSignIn();
+    if (user === undefined || user.expired)
+      throw new Error("Authorization error: Silent sign-in failed");
+  }
+
+  /**
    * Attempts a non-interactive signIn
    * - tries to load the user from storage
    * - tries to silently sign-in the user
@@ -235,11 +249,16 @@ export class BrowserAuthorizationClient implements AuthorizationClient {
 
     // Attempt a silent sign-in
     try {
-      user = (await userManager.signinSilent()) ?? undefined; // calls events
+      user = await this.performSilentSignIn(); // calls events
       return user;
     } catch {
       return undefined;
     }
+  }
+
+  protected async performSilentSignIn(): Promise<User | undefined> {
+    const userManager = await this.getUserManager();
+    return (await userManager.signinSilent()) ?? undefined;
   }
 
   /**

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -51,12 +51,12 @@ to complete the process. Once back on your initial page, the call to `client.sig
 If the callback occurs on a page where the configured `client` is not available, you can use the static method to complete the process:
 
 ```typescript
-await BrowserAuthorizationClient.handleSigninCallback()
+await BrowserAuthorizationClient.handleSignInCallback()
 
 // This library defaults to localStorage for storing state.
 // To use sessionStorage (or another Storage object), you can pass it as an argument.
 // If overriding the default localStorage, also set the stateStore via client.setAdvancedSettings({stateStore: yourStore})
-await BrowserAuthorizationClient.handleSigninCallback(window.sessionStorage)
+await BrowserAuthorizationClient.handleSignInCallback(window.sessionStorage)
 ```
 
 This will pull the client configuration from localStorage, using the state nonce provided by OIDC to select the proper configuration.
@@ -64,6 +64,8 @@ This will pull the client configuration from localStorage, using the state nonce
 Other notable methods:
 `client.signOutRedirect()` - starts the signout flow via redirect
 `client.signOutPopup()` - starts the signout flow via popup.
+`client.forceSilentRenew()` - forces a silent token renewal even when a cached user already exists locally.
+`client.accessTokenExpiresAt` - returns the current access token expiration time, if known.
 `client.setAdvancedSettings(userManagerSettings)` - Allows for advanced options to be supplied to the underlying UserManager.
 
  */

--- a/packages/browser/src/integration-tests/integration.test.ts
+++ b/packages/browser/src/integration-tests/integration.test.ts
@@ -93,3 +93,29 @@ test("signout popup", async ({ page }) => {
   const content = signOutPopup.getByText("Sign Off Successful");
   expect(content).toBeDefined();
 });
+
+test("silent renew - manual token refresh", async ({ page }) => {
+  await page.goto(signInOptions.url);
+  await testHelper.signIn(page);
+  await page.waitForURL(signInOptions.url);
+
+  await testHelper.validateAuthenticated(page);
+
+  // Capture the initial access token
+  const initialUser = await testHelper.getUserFromLocalStorage(page);
+  const initialAccessToken = initialUser.access_token;
+
+  // Trigger manual silent renew
+  const silentRenewButton = page.getByTestId("silent-renew-button");
+  await silentRenewButton.click();
+
+  // Wait for silent renew to complete
+  await page.waitForTimeout(2000);
+
+  // Verify that a new token was obtained
+  const renewedUser = await testHelper.getUserFromLocalStorage(page);
+  const renewedAccessToken = renewedUser.access_token;
+
+  expect(renewedAccessToken).toBeDefined();
+  expect(renewedAccessToken).not.toEqual(initialAccessToken);
+});

--- a/packages/browser/src/integration-tests/integration.test.ts
+++ b/packages/browser/src/integration-tests/integration.test.ts
@@ -101,21 +101,30 @@ test("silent renew - manual token refresh", async ({ page }) => {
 
   await testHelper.validateAuthenticated(page);
 
-  // Capture the initial access token
   const initialUser = await testHelper.getUserFromLocalStorage(page);
+  const initialExpiresAt = initialUser.expires_at ?? 0;
   const initialAccessToken = initialUser.access_token;
 
-  // Trigger manual silent renew
   const silentRenewButton = page.getByTestId("silent-renew-button");
   await silentRenewButton.click();
 
-  // Wait for silent renew to complete
-  await page.waitForTimeout(2000);
+  await expect
+    .poll(
+      async () => {
+        const user = await testHelper.getUserFromLocalStorage(page);
+        return (
+          user.access_token !== initialAccessToken ||
+          (user.expires_at ?? 0) > initialExpiresAt
+        );
+      },
+      { timeout: 10000 },
+    )
+    .toBe(true);
 
-  // Verify that a new token was obtained
   const renewedUser = await testHelper.getUserFromLocalStorage(page);
-  const renewedAccessToken = renewedUser.access_token;
-
-  expect(renewedAccessToken).toBeDefined();
-  expect(renewedAccessToken).not.toEqual(initialAccessToken);
+  expect(renewedUser.access_token).toBeDefined();
+  expect(
+    renewedUser.access_token !== initialAccessToken ||
+      (renewedUser.expires_at ?? 0) > initialExpiresAt,
+  ).toBe(true);
 });

--- a/packages/browser/src/integration-tests/test-app/index.ts
+++ b/packages/browser/src/integration-tests/test-app/index.ts
@@ -6,7 +6,9 @@
 import { BrowserAuthorizationClient } from "../../Client";
 
 const oidcCallbackUrl = `${process.env.ITJS_AUTH_CLIENTS_BROWSER_BASE_URL}/oidc-callback`;
+const silentRenewUrl = `${process.env.ITJS_AUTH_CLIENTS_BROWSER_BASE_URL}/silent-renew.html`;
 const authority = `https://${process.env.IMJS_URL_PREFIX}ims.bentley.com`;
+
 const client = new BrowserAuthorizationClient({
   clientId: process.env.ITJS_AUTH_CLIENTS_BROWSER_CLIENT_ID!,
   redirectUri: oidcCallbackUrl,
@@ -14,7 +16,7 @@ const client = new BrowserAuthorizationClient({
   authority,
   postSignoutRedirectUri: "",
   responseType: "code",
-  silentRedirectUri: oidcCallbackUrl,
+  silentRedirectUri: silentRenewUrl,
 });
 
 const contentArea = document.querySelector("div[data-testid='content']");
@@ -64,19 +66,72 @@ async function validateAuthenticated() {
 }
 
 async function signout(popup: boolean) {
-  if (popup)
-    await client.signOutPopup();
-  else
-    await client.signOutRedirect();
+  if (popup) await client.signOutPopup();
+  else await client.signOutRedirect();
 }
 
 function displayAuthorized() {
   if (contentArea) {
     contentArea.textContent = "Authorized!";
 
+    // Display token info for testing
+    displayTokenInfo();
+
+    // Listen for token changes (including automatic silent renewal)
+    client.onAccessTokenChanged.addListener((token: string) => {
+      // eslint-disable-next-line no-console
+      console.log("Access token changed");
+      displayTokenInfo();
+    });
+
     appendButton(contentArea, "Signout", "signout-button");
     appendButton(contentArea, "Signout Popup", "signout-button-popup", true);
+    appendButton(
+      contentArea,
+      "Silent Renew",
+      "silent-renew-button",
+      false,
+      async () => {
+        try {
+          // Access the internal userManager directly to force a silent renew
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const userManager = (client as any)._userManager;
+          if (userManager) {
+            await userManager.signinSilent();
+            // eslint-disable-next-line no-console
+            console.log("Silent renew succeeded");
+          }
+        } catch (error) {
+          // interaction_required is expected when IDP session can't be renewed silently
+          // eslint-disable-next-line no-console
+          console.error("Silent renew failed:", error);
+        }
+      },
+    );
   }
+}
+
+async function displayTokenInfo() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const userManager = (client as any)._userManager;
+  if (!userManager) return;
+
+  const user = await userManager.getUser();
+  if (!user) return;
+
+  let tokenInfoEl = document.getElementById("token-info");
+  if (!tokenInfoEl) {
+    tokenInfoEl = document.createElement("div");
+    tokenInfoEl.id = "token-info";
+    tokenInfoEl.setAttribute("data-testid", "token-info");
+    contentArea?.appendChild(tokenInfoEl);
+  }
+
+  const expiresAt = user.expires_at ? new Date(user.expires_at * 1000) : null;
+  tokenInfoEl.innerHTML = `
+    <p>Token expires at: <span data-testid="token-expires-at">${expiresAt?.toISOString() ?? "unknown"}</span></p>
+    <p>Token (last 10 chars): <span data-testid="token-suffix">${user.access_token.slice(-10)}</span></p>
+  `;
 }
 
 function appendButton(
@@ -84,15 +139,17 @@ function appendButton(
   text: string,
   testId: string,
   popup: boolean = false,
-  clickHandler?: () => void
+  clickHandler?: () => void,
 ) {
   const button = document.createElement("button");
   button.textContent = text;
   button.setAttribute("data-testid", testId);
   button.setAttribute("id", testId);
-  const handler = clickHandler ?? (async () => {
-    await signout(popup);
-  })
+  const handler =
+    clickHandler ??
+    (async () => {
+      await signout(popup);
+    });
   button.addEventListener("click", handler);
   parent.appendChild(button);
 }

--- a/packages/browser/src/integration-tests/test-app/index.ts
+++ b/packages/browser/src/integration-tests/test-app/index.ts
@@ -75,13 +75,13 @@ function displayAuthorized() {
     contentArea.textContent = "Authorized!";
 
     // Display token info for testing
-    displayTokenInfo();
+    void displayTokenInfo();
 
     // Listen for token changes (including automatic silent renewal)
-    client.onAccessTokenChanged.addListener((token: string) => {
+    client.onAccessTokenChanged.addListener(() => {
       // eslint-disable-next-line no-console
       console.log("Access token changed");
-      displayTokenInfo();
+      void displayTokenInfo();
     });
 
     appendButton(contentArea, "Signout", "signout-button");
@@ -93,14 +93,9 @@ function displayAuthorized() {
       false,
       async () => {
         try {
-          // Access the internal userManager directly to force a silent renew
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const userManager = (client as any)._userManager;
-          if (userManager) {
-            await userManager.signinSilent();
-            // eslint-disable-next-line no-console
-            console.log("Silent renew succeeded");
-          }
+          await client.forceSilentRenew();
+          // eslint-disable-next-line no-console
+          console.log("Silent renew succeeded");
         } catch (error) {
           // interaction_required is expected when IDP session can't be renewed silently
           // eslint-disable-next-line no-console
@@ -112,14 +107,13 @@ function displayAuthorized() {
 }
 
 async function displayTokenInfo() {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const userManager = (client as any)._userManager;
-  if (!userManager) return;
-
-  const user = await userManager.getUser();
-  if (!user) return;
-
   let tokenInfoEl = document.getElementById("token-info");
+  if (!client.hasSignedIn) {
+    tokenInfoEl?.remove();
+    return;
+  }
+
+  const accessToken = await client.getAccessToken();
   if (!tokenInfoEl) {
     tokenInfoEl = document.createElement("div");
     tokenInfoEl.id = "token-info";
@@ -127,11 +121,32 @@ async function displayTokenInfo() {
     contentArea?.appendChild(tokenInfoEl);
   }
 
-  const expiresAt = user.expires_at ? new Date(user.expires_at * 1000) : null;
-  tokenInfoEl.innerHTML = `
-    <p>Token expires at: <span data-testid="token-expires-at">${expiresAt?.toISOString() ?? "unknown"}</span></p>
-    <p>Token (last 10 chars): <span data-testid="token-suffix">${user.access_token.slice(-10)}</span></p>
-  `;
+  const expiresAt = client.accessTokenExpiresAt;
+  tokenInfoEl.replaceChildren(
+    createTokenInfoRow(
+      "Token expires at:",
+      "token-expires-at",
+      expiresAt?.toISOString() ?? "unknown",
+    ),
+    createTokenInfoRow(
+      "Token (last 10 chars):",
+      "token-suffix",
+      accessToken.slice(-10),
+    ),
+  );
+}
+
+function createTokenInfoRow(
+  labelText: string,
+  testId: string,
+  value: string,
+): HTMLParagraphElement {
+  const row = document.createElement("p");
+  const valueEl = document.createElement("span");
+  valueEl.setAttribute("data-testid", testId);
+  valueEl.textContent = value;
+  row.append(`${labelText} `, valueEl);
+  return row;
 }
 
 function appendButton(

--- a/packages/browser/src/integration-tests/test-app/silent-renew.html
+++ b/packages/browser/src/integration-tests/test-app/silent-renew.html
@@ -1,0 +1,17 @@
+<!-----------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *---------------------------------------------------------------------------------------------->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <title>Silent Renew</title>
+</head>
+
+<body>
+  <script type="module" src="./silent-renew.ts"></script>
+</body>
+
+</html>

--- a/packages/browser/src/integration-tests/test-app/silent-renew.ts
+++ b/packages/browser/src/integration-tests/test-app/silent-renew.ts
@@ -4,12 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { BrowserAuthorizationClient } from "../../Client";
-
-// import { UserManager } from "oidc-client-ts";
-
 // // This page handles the silent renew callback in an iframe
 // // It's intentionally minimal to load quickly
-// // We use signinSilentCallback directly because BrowserAuthorizationClient.handleSignInCallback
-// // checks against redirectUri, not silentRedirectUri
-// new UserManager({ authority: "", client_id: "" }).signinSilentCallback();
+
 BrowserAuthorizationClient.handleSignInCallback();

--- a/packages/browser/src/integration-tests/test-app/silent-renew.ts
+++ b/packages/browser/src/integration-tests/test-app/silent-renew.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { BrowserAuthorizationClient } from "../../Client";
+
+// import { UserManager } from "oidc-client-ts";
+
+// // This page handles the silent renew callback in an iframe
+// // It's intentionally minimal to load quickly
+// // We use signinSilentCallback directly because BrowserAuthorizationClient.handleSignInCallback
+// // checks against redirectUri, not silentRedirectUri
+// new UserManager({ authority: "", client_id: "" }).signinSilentCallback();
+BrowserAuthorizationClient.handleSignInCallback();

--- a/packages/browser/src/integration-tests/test-app/silent-renew.ts
+++ b/packages/browser/src/integration-tests/test-app/silent-renew.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { BrowserAuthorizationClient } from "../../Client";
-// // This page handles the silent renew callback in an iframe
-// // It's intentionally minimal to load quickly
+// This page handles the silent renew callback in an iframe.
+// It's intentionally minimal to load quickly.
 
-BrowserAuthorizationClient.handleSignInCallback();
+void BrowserAuthorizationClient.handleSignInCallback();

--- a/packages/browser/src/test/BrowserAuthorizationClient.test.ts
+++ b/packages/browser/src/test/BrowserAuthorizationClient.test.ts
@@ -3,14 +3,27 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { assert } from "chai";
+import * as sinon from "sinon";
+import type { User } from "oidc-client-ts";
 import { BrowserAuthorizationClient } from "../Client";
 import { getImsAuthority } from "../utils";
 import type { BrowserAuthorizationClientConfiguration } from "../types";
 
 describe("BrowserAuthorizationClient", () => {
-  describe("#constructor", () => {
-    const TEST_AUTHORITY = "https://test.authority.com";
+  const TEST_AUTHORITY = "https://test.authority.com";
+  const TEST_CONFIG: BrowserAuthorizationClientConfiguration = {
+    authority: TEST_AUTHORITY,
+    clientId: "test_clientId",
+    redirectUri: "test_redirectUri",
+    postSignoutRedirectUri: "test_postSignoutRedirectUri",
+    scope: "test_scope",
+    responseType: "code",
+    noSilentSignInOnAppStartup: false,
+    silentRedirectUri: "test_silentRedirectUri",
+    responseMode: "query",
+  };
 
+  describe("#constructor", () => {
     let testClient: BrowserAuthorizationClient;
     let testConfig: BrowserAuthorizationClientConfiguration;
     let testConfigWithoutAuthority: BrowserAuthorizationClientConfiguration;
@@ -138,6 +151,52 @@ describe("BrowserAuthorizationClient", () => {
       });
 
       assert.equal(client["_basicSettings"].responseMode, "fragment"); // eslint-disable-line @typescript-eslint/dot-notation
+    });
+  });
+
+  describe("#forceSilentRenew", () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("calls signinSilent on the underlying user manager", async () => {
+      const client = new BrowserAuthorizationClient(TEST_CONFIG);
+      const signinSilent = sinon.stub().resolves({ expired: false } as User);
+      sinon
+        .stub(client as any, "getUserManager")
+        .resolves({ signinSilent } as any);
+
+      await client.forceSilentRenew();
+
+      sinon.assert.calledOnce(signinSilent);
+    });
+
+    it("throws when silent renew does not return an active user", async () => {
+      const client = new BrowserAuthorizationClient(TEST_CONFIG);
+      const signinSilent = sinon.stub().resolves({ expired: true } as User);
+      sinon
+        .stub(client as any, "getUserManager")
+        .resolves({ signinSilent } as any);
+
+      try {
+        await client.forceSilentRenew();
+        assert.fail("Expected forceSilentRenew to throw");
+      } catch (error: any) {
+        assert.equal(error.message, "Authorization error: Silent sign-in failed");
+      }
+    });
+  });
+
+  describe("#accessTokenExpiresAt", () => {
+    it("returns a copy of the current access token expiration time", () => {
+      const client = new BrowserAuthorizationClient(TEST_CONFIG);
+      const expiresAt = new Date("2026-01-01T00:00:00.000Z");
+      client["_expiresAt"] = expiresAt; // eslint-disable-line @typescript-eslint/dot-notation
+
+      const result = client.accessTokenExpiresAt;
+
+      assert.deepEqual(result, expiresAt);
+      assert.notStrictEqual(result, expiresAt);
     });
   });
 });


### PR DESCRIPTION
We now have an example we can point to for colleagues needing help with silent renew. Add silent renew integration test. Refresh SPA client id (no changes here).