### PR TITLE
fix(oidc-signin-tool): replace deprecated Playwright APIs to fix Chromium 146+ sign-in failures

### DIFF
--- a/change/@itwin-browser-authorization-74638f83-f1b6-44e3-8a86-de66ccfc9af4.json
+++ b/change/@itwin-browser-authorization-74638f83-f1b6-44e3-8a86-de66ccfc9af4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update vite devDependency to fix audit vulnerability",
+  "packageName": "@itwin/browser-authorization",
+  "email": "50554904+hl662@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@itwin-electron-authorization-5989893a-f737-451a-aa62-0f470aab1e60.json
+++ b/change/@itwin-electron-authorization-5989893a-f737-451a-aa62-0f470aab1e60.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update vite devDependency to fix audit vulnerability",
+  "packageName": "@itwin/electron-authorization",
+  "email": "50554904+hl662@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@itwin-oidc-signin-tool-71ab825d-2313-4709-b445-f9f9c21e06f3.json
+++ b/change/@itwin-oidc-signin-tool-71ab825d-2313-4709-b445-f9f9c21e06f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Replace deprecated Playwright page.$() and page.waitForSelector() APIs with modern locator-based equivalents to fix \"Execution context was destroyed\" errors on Chromium 146+ (Electron 41)",
+  "packageName": "@itwin/oidc-signin-tool",
+  "email": "50554904+hl662@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   },
   "pnpm": {
     "overrides": {
-      "path-to-regexp@<0.1.13": ">=0.1.13",
-      "lodash@<=4.17.23": ">=4.18.0",
+      "path-to-regexp@<0.1.13": "0.1.13",
+      "lodash@<=4.17.23": "4.18.1",
       "serialize-javascript@<=7.0.2": ">=7.0.3",
       "picomatch@<2.3.2": ">=2.3.2"
     }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   },
   "pnpm": {
     "overrides": {
-      "path-to-regexp": "0.1.12",
+      "path-to-regexp@<0.1.13": ">=0.1.13",
+      "lodash@<=4.17.23": ">=4.18.0",
       "serialize-javascript@<=7.0.2": ">=7.0.3",
       "picomatch@<2.3.2": ">=2.3.2"
     }

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -52,7 +52,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^15.2.0",
     "typescript": "~5.6.3",
-    "vite": "^6.3.5"
+    "vite": "^6.4.2"
   },
   "peerDependencies": {
     "@itwin/core-bentley": "^5.0.0"

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -71,7 +71,7 @@
     "sinon": "^15.2.0",
     "source-map-support": "^0.5.21",
     "typescript": "~5.6.3",
-    "vite": "^6.3.5"
+    "vite": "^6.4.2"
   },
   "peerDependencies": {
     "@itwin/core-bentley": "^5.0.0",

--- a/packages/oidc-signin-tool/src/SignInAutomation.ts
+++ b/packages/oidc-signin-tool/src/SignInAutomation.ts
@@ -156,9 +156,7 @@ async function handlePingLoginPage<T>(context: AutomatedSignInContext<T>): Promi
   }
   await page.locator(testSelectors.pingEmail).fill(context.user.email);
 
-  await page.waitForSelector(testSelectors.pingAllowSubmit);
-  let allow = page.locator(testSelectors.pingAllowSubmit);
-  await allow.click();
+  await page.locator(testSelectors.pingAllowSubmit).click();
 
   // Cut out for federated sign-in
   if (-1 !== page.url().indexOf("microsoftonline"))
@@ -166,9 +164,7 @@ async function handlePingLoginPage<T>(context: AutomatedSignInContext<T>): Promi
 
   await page.locator(testSelectors.pingPassword).fill(context.user.password);
 
-  await page.waitForSelector(testSelectors.pingAllowSubmit);
-  allow = page.locator(testSelectors.pingAllowSubmit);
-  await allow.click();
+  await page.locator(testSelectors.pingAllowSubmit).click();
 
   const error = page.getByText(
     "We didn't recognize the email address or password you entered. Please try again.",
@@ -194,14 +190,16 @@ async function handleFederatedSignin<T>(context: AutomatedSignInContext<T>): Pro
     return;
 
   // Wait for either msUserNameField or fedPassword to be visible
-  const msUserNameFieldPromise = page.waitForSelector(testSelectors.msUserNameField, { state: "visible" });
-  const fedPasswordPromise = page.waitForSelector(testSelectors.fedPassword, { state: "visible" });
-  await Promise.race([msUserNameFieldPromise, fedPasswordPromise]);
+  const msPromise = page.locator(testSelectors.msUserNameField).waitFor({ state: "visible" }).then(() => "ms" as const);
+  const fedPromise = page.locator(testSelectors.fedPassword).waitFor({ state: "visible" }).then(() => "fed" as const);
+  // Suppress unhandled rejection from the losing race participant
+  msPromise.catch(() => {});
+  fedPromise.catch(() => {});
+  const winner = await Promise.race([msPromise, fedPromise]);
 
-  if (await checkSelectorExists(page, testSelectors.msUserNameField)) {
+  if (winner === "ms") {
     await page.locator(testSelectors.msUserNameField).fill(context.user.email);
-    const msSubmit = await page.waitForSelector(testSelectors.msSubmit);
-    await msSubmit.click();
+    await page.locator(testSelectors.msSubmit).click();
 
     // Checks for the error in username entered
     await checkErrorOnPage(page, "#usernameError");
@@ -210,8 +208,7 @@ async function handleFederatedSignin<T>(context: AutomatedSignInContext<T>): Pro
   }
 
   await page.locator(testSelectors.fedPassword).fill(context.user.password);
-  const submit = await page.waitForSelector(testSelectors.fedSubmit);
-  await submit.click();
+  await page.locator(testSelectors.fedSubmit).click();
 
   // Need to check for invalid username/password directly after the submit button is pressed
   let errorExists = false;
@@ -229,8 +226,7 @@ async function handleFederatedSignin<T>(context: AutomatedSignInContext<T>): Pro
     -1 !== page.url().indexOf("microsoftonline") &&
     (await checkSelectorExists(page, testSelectors.msSubmit))
   ) {
-    const msSubmit = await page.waitForSelector(testSelectors.msSubmit);
-    await msSubmit.click();
+    await page.locator(testSelectors.msSubmit).click();
   }
 }
 
@@ -247,13 +243,10 @@ async function handleConsentPage<T>(context: AutomatedSignInContext<T>): Promise
   const pageTitle = await page.title();
 
   if (pageTitle === "Request for Approval") {
-    const pingSubmit = await page.waitForSelector(
-      testSelectors.pingAllowSubmit,
-    );
-    await pingSubmit.click();
+    await page.locator(testSelectors.pingAllowSubmit).click();
   } else if ((await page.title()) === "Permissions") {
     // Another new consent page...
-    const acceptButton = await page.waitForSelector(
+    const acceptButton = page.locator(
       "xpath=(//button/span[text()='Accept'] | //div[contains(@class, 'ping-buttons')]/a[text()='Accept'])[1]",
     );
 
@@ -272,17 +265,27 @@ async function checkSelectorExists(
   page: Page,
   selector: string,
 ): Promise<boolean> {
-  const element = await page.$(selector);
-  return !!element;
+  try {
+    return (await page.locator(selector).count()) > 0;
+  } catch {
+    // Page likely navigated away — element doesn't exist in the new context
+    return false;
+  }
 }
 
 async function checkErrorOnPage(page: Page, selector: string): Promise<void> {
-  const errMsgElement = await page.$(selector);
-  if (errMsgElement) {
-    const errMsgText = await errMsgElement.textContent();
-    if (undefined !== errMsgText && null !== errMsgText)
-      throw new Error(errMsgText);
+  let errMsgText: string | null | undefined;
+  try {
+    const errMsgElement = page.locator(selector).first();
+    if ((await errMsgElement.count()) === 0)
+      return;
+    errMsgText = await errMsgElement.textContent();
+  } catch {
+    // Page likely navigated away — no error to check
+    return;
   }
+  if (undefined !== errMsgText && null !== errMsgText)
+    throw new Error(errMsgText);
 }
 
 /** @internal use playwright to launch the default automation page, which is a chromium instance */

--- a/packages/oidc-signin-tool/src/SignInAutomation.ts
+++ b/packages/oidc-signin-tool/src/SignInAutomation.ts
@@ -193,8 +193,8 @@ async function handleFederatedSignin<T>(context: AutomatedSignInContext<T>): Pro
   const msPromise = page.locator(testSelectors.msUserNameField).waitFor({ state: "visible" }).then(() => "ms" as const);
   const fedPromise = page.locator(testSelectors.fedPassword).waitFor({ state: "visible" }).then(() => "fed" as const);
   // Suppress unhandled rejection from the losing race participant
-  msPromise.catch(() => {});
-  fedPromise.catch(() => {});
+  void msPromise.catch(() => {});
+  void fedPromise.catch(() => {});
   const winner = await Promise.race([msPromise, fedPromise]);
 
   if (winner === "ms") {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  path-to-regexp: 0.1.12
+  path-to-regexp@<0.1.13: '>=0.1.13'
+  lodash@<=4.17.23: '>=4.18.0'
   serialize-javascript@<=7.0.2: '>=7.0.3'
   picomatch@<2.3.2: '>=2.3.2'
 
@@ -78,8 +79,8 @@ importers:
         specifier: ~5.6.3
         version: 5.6.3
       vite:
-        specifier: ^6.3.5
-        version: 6.4.1(@types/node@20.19.37)(yaml@2.8.3)
+        specifier: ^6.4.2
+        version: 6.4.2(@types/node@20.19.37)(yaml@2.8.3)
 
   packages/electron:
     dependencies:
@@ -160,8 +161,8 @@ importers:
         specifier: ~5.6.3
         version: 5.6.3
       vite:
-        specifier: ^6.3.5
-        version: 6.4.1(@types/node@20.19.37)(yaml@2.8.3)
+        specifier: ^6.4.2
+        version: 6.4.2(@types/node@20.19.37)(yaml@2.8.3)
 
   packages/node-cli:
     dependencies:
@@ -2750,8 +2751,8 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -3188,8 +3189,11 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  path-to-regexp@0.1.12:
-    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -3821,8 +3825,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@6.4.1:
-    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -4283,7 +4287,7 @@ snapshots:
       detect-port: 1.3.0
       express: 4.22.1
       jsonc-parser: 2.0.3
-      lodash: 4.17.23
+      lodash: 4.18.1
       mocha: 11.7.5
       playwright: 1.56.1
       source-map-support: 0.5.21
@@ -4363,7 +4367,7 @@ snapshots:
       '@rushstack/terminal': 0.22.3(@types/node@20.19.37)
       '@rushstack/ts-command-line': 5.3.3(@types/node@20.19.37)
       diff: 8.0.4
-      lodash: 4.17.23
+      lodash: 4.18.1
       minimatch: 10.2.3
       resolve: 1.22.11
       semver: 7.5.4
@@ -5799,7 +5803,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.12
+      path-to-regexp: 8.4.2
       proxy-addr: 2.0.7
       qs: 6.14.2
       range-parser: 1.2.1
@@ -6034,7 +6038,7 @@ snapshots:
     dependencies:
       glob: 7.2.3
       ignore: 5.3.2
-      lodash: 4.17.23
+      lodash: 4.18.1
       make-array: 1.0.5
       util.inherits: 1.0.3
 
@@ -6651,7 +6655,7 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -6868,7 +6872,7 @@ snapshots:
       '@sinonjs/fake-timers': 11.3.1
       '@sinonjs/text-encoding': 0.7.3
       just-extend: 6.2.0
-      path-to-regexp: 0.1.12
+      path-to-regexp: 6.3.0
 
   node-exports-info@1.6.0:
     dependencies:
@@ -7120,7 +7124,9 @@ snapshots:
       lru-cache: 11.2.7
       minipass: 7.1.3
 
-  path-to-regexp@0.1.12: {}
+  path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -7842,7 +7848,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1(@types/node@20.19.37)(yaml@2.8.3):
+  vite@6.4.2(@types/node@20.19.37)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  path-to-regexp@<0.1.13: '>=0.1.13'
-  lodash@<=4.17.23: '>=4.18.0'
+  path-to-regexp@<0.1.13: 0.1.13
+  lodash@<=4.17.23: 4.18.1
   serialize-javascript@<=7.0.2: '>=7.0.3'
   picomatch@<2.3.2: '>=2.3.2'
 
@@ -3189,11 +3189,11 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
+  path-to-regexp@0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
+
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
-
-  path-to-regexp@8.4.2:
-    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -5803,7 +5803,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 8.4.2
+      path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
       qs: 6.14.2
       range-parser: 1.2.1
@@ -7124,9 +7124,9 @@ snapshots:
       lru-cache: 11.2.7
       minipass: 7.1.3
 
-  path-to-regexp@6.3.0: {}
+  path-to-regexp@0.1.13: {}
 
-  path-to-regexp@8.4.2: {}
+  path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
 


### PR DESCRIPTION
## Why

Chromium 146 (shipped in Electron 41) changed the timing of OAuth redirects — they now complete before in-flight CDP commands return. The OIDC sign-in automation in this package uses Playwright's deprecated `page.$()` API, which sends eager CDP queries. When a redirect races ahead of the response, the execution context is already gone and the query throws "Execution context was destroyed", failing every E2E test that signs in through a separate Electron window.

## What

Replaced all deprecated `page.$()` and `page.waitForSelector()` calls in `SignInAutomation.ts` with Playwright's locator API, which binds lazily and tolerates navigations. Error-checking helpers (`checkSelectorExists`, `checkErrorOnPage`) now catch context-destroyed failures gracefully, and the federated sign-in flow branches on the `Promise.race` winner directly instead of re-querying the DOM.