### PR TITLE
Allow passing in `playwright` page

### DIFF
--- a/change/@itwin-oidc-signin-tool-f94d62ff-891e-4f65-a154-dd105ce33a9b.json
+++ b/change/@itwin-oidc-signin-tool-f94d62ff-891e-4f65-a154-dd105ce33a9b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add optional page parameter to getAccessToken/getTestAccessToken/TestUtility.getAccessToken so consumers can supply their own Playwright Page, avoiding 'multiple playwright dependencies active' runtime errors.",
+  "packageName": "@itwin/oidc-signin-tool",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-oidc-signin-tool-f94d62ff-891e-4f65-a154-dd105ce33a9b.json
+++ b/change/@itwin-oidc-signin-tool-f94d62ff-891e-4f65-a154-dd105ce33a9b.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add optional page parameter to getAccessToken/getTestAccessToken/TestUtility.getAccessToken so consumers can supply their own Playwright Page, avoiding 'multiple playwright dependencies active' runtime errors.",
+  "comment": "Add optional Playwright `page` parameter to getAccessToken/getTestAccessToken/TestUtility.getAccessToken so consumers can supply their own Page.",
   "packageName": "@itwin/oidc-signin-tool",
   "email": "24278440+saskliutas@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/oidc-signin-tool/README.md
+++ b/packages/oidc-signin-tool/README.md
@@ -50,6 +50,42 @@ client.hasSignedIn
 
 ```
 
+## Bring your own Playwright
+
+By default the tool dynamically imports its own copy of `@playwright/test` to
+launch the headless browser that drives the sign-in UI. If your project already
+depends on Playwright, loading two Playwright instances at once throws:
+
+> Could not load @playwright/test. Do you have multiple playwright dependencies active? ...
+
+To avoid this, build a Playwright `Page` with your own Playwright and pass it via
+the `page` option. The tool then drives that page instead of importing its own
+Playwright, so no second instance is loaded:
+
+```typescript
+import { chromium } from "@playwright/test";
+import { getTestAccessToken, TestBrowserAuthorizationClient } from "@itwin/oidc-signin-tool";
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+
+// convenience function
+const accessToken = await getTestAccessToken(config, user, { page });
+
+// or on the client
+const client = new TestBrowserAuthorizationClient(config, user);
+const token = await client.getAccessToken({ page });
+
+// you own the lifecycle of the page and browser:
+await browser.close();
+```
+
+The option is also available on `client.signIn()` and
+`TestUtility.getAccessToken()`. When you supply a `page`, the tool does **not**
+close your page or browser — you are responsible for cleaning them up. When the
+option is omitted, the existing dynamic-import behavior is used, so this is fully
+backwards compatible.
+
 ## Mocha leaks
 
 If you use this package with mocha, you may notice a global leak.
@@ -65,6 +101,9 @@ used to ignore because it was created during the import phase. Now it is created
 conditional import where mocha doesn't expect it and it "leaks". **You should configure mocha to ignore
 this leak.** In the future, the API requiring the dynamic import will be moved to a separate package
 to avoid this situation.
+
+> Note: passing your own `page` (see [Bring your own Playwright](#bring-your-own-playwright))
+> skips the dynamic import entirely, which also avoids this leak.
 
 You can ignore the leak like so:
 

--- a/packages/oidc-signin-tool/README.md
+++ b/packages/oidc-signin-tool/README.md
@@ -83,8 +83,7 @@ await browser.close();
 The option is also available on `client.signIn()` and
 `TestUtility.getAccessToken()`. When you supply a `page`, the tool does **not**
 close your page or browser — you are responsible for cleaning them up. When the
-option is omitted, the existing dynamic-import behavior is used, so this is fully
-backwards compatible.
+option is omitted, the default dynamic import behavior is used.
 
 ## Mocha leaks
 

--- a/packages/oidc-signin-tool/src/SignInAutomation.ts
+++ b/packages/oidc-signin-tool/src/SignInAutomation.ts
@@ -33,6 +33,10 @@ interface AutomatedContextBase<T> {
 
   /** whether or not to kill the entire browser when cleaning up */
   doNotKillBrowser?: boolean;
+
+  /** whether or not to leave the page open when cleaning up.
+   * Useful when the consumer supplies their own page and owns its lifecycle. */
+  doNotClosePage?: boolean;
 }
 
 /** @internal context for automated sign in functions */
@@ -87,7 +91,7 @@ export async function automatedSignIn<T>(
       // eslint-disable-next-line @typescript-eslint/return-await
       return await context.resultFromCallback(await waitForCallback);
   } finally {
-    await cleanup(page, controller.signal, waitForCallback, context.doNotKillBrowser);
+    await cleanup(page, controller.signal, waitForCallback, context.doNotKillBrowser, context.doNotClosePage);
   }
 }
 
@@ -106,7 +110,7 @@ export async function automatedSignOut<T>(
   try {
     await page.goto(context.signOutInitUrl);
   } finally {
-    await cleanup(page, controller.signal, waitForCallback, context.doNotKillBrowser);
+    await cleanup(page, controller.signal, waitForCallback, context.doNotKillBrowser, context.doNotClosePage);
   }
 }
 
@@ -351,10 +355,15 @@ async function cleanup(
   signal: AbortSignal,
   waitForCallbackUrl: Promise<any>,
   doNotKillBrowser = false,
+  doNotClosePage = false,
 ) {
   if (signal.aborted)
     await page.reload();
   await waitForCallbackUrl;
+
+  if (doNotClosePage)
+    return;
+
   await page.close();
 
   const doKillBrowser = !doNotKillBrowser;

--- a/packages/oidc-signin-tool/src/SignInAutomation.ts
+++ b/packages/oidc-signin-tool/src/SignInAutomation.ts
@@ -8,6 +8,77 @@ import type { Browser, LaunchOptions, Page } from "@playwright/test";
 import type { TestUserCredentials } from "./TestUsers";
 import { testSelectors } from "./TestSelectors";
 
+/* The following `*Like` interfaces describe the minimal subset of the Playwright
+ * API that the sign-in automation actually uses. They are declared structurally
+ * so that a `Page` from *any* Playwright installation/version satisfies them,
+ * without baking this package's exact `@playwright/test` type identity into the
+ * public API. A real Playwright `Page` is assignable to `PageLike`.
+ *
+ * Return types for calls whose results are ignored are widened to
+ * `Promise<unknown>` so that Playwright's more specific return types (e.g.
+ * `Promise<Response | null>`) remain assignable. */
+
+/**
+ * The minimal subset of the Playwright `Locator` API used by the automation.
+ * @alpha
+ */
+export interface LocatorLike {
+  fill(value: string): Promise<unknown>;
+  click(): Promise<unknown>;
+  isVisible(): Promise<boolean>;
+  count(): Promise<number>;
+  textContent(): Promise<string | null>;
+  first(): LocatorLike;
+  waitFor(options?: { state?: "attached" | "detached" | "visible" | "hidden" }): Promise<unknown>;
+}
+
+/**
+ * The minimal subset of the Playwright `Browser` API used by the automation.
+ * @alpha
+ */
+export interface BrowserLike {
+  close(): Promise<unknown>;
+}
+
+/**
+ * The minimal subset of the Playwright `BrowserContext` API used by the automation.
+ * @alpha
+ */
+export interface BrowserContextLike {
+  close(): Promise<unknown>;
+  browser(): BrowserLike | null;
+}
+
+/**
+ * The minimal subset of the Playwright `Request` API used by the automation.
+ * @alpha
+ */
+export interface RequestLike {
+  url(): string;
+}
+
+/**
+ * The minimal subset of the Playwright `Page` API used by the automation.
+ *
+ * A real Playwright `Page` satisfies this interface, so you can supply a page
+ * created by *your own* Playwright installation/version without being forced
+ * onto this package's exact `@playwright/test` types.
+ * @alpha
+ */
+export interface PageLike {
+  goto(url: string): Promise<unknown>;
+  title(): Promise<string>;
+  content(): Promise<string>;
+  url(): string;
+  reload(): Promise<unknown>;
+  close(): Promise<unknown>;
+  click(selector: string): Promise<unknown>;
+  locator(selector: string): LocatorLike;
+  getByText(text: string): LocatorLike;
+  context(): BrowserContextLike;
+  waitForRequest(urlOrPredicate: (request: RequestLike) => boolean): Promise<RequestLike>;
+}
+
 /** @internal configuration for automated sign in */
 export interface AutomatedSignInConfig {
   issuer: string;
@@ -17,7 +88,7 @@ export interface AutomatedSignInConfig {
 
 /** @internal base context for automated sign in and sign out functions */
 interface AutomatedContextBase<T> {
-  page: Page;
+  page: PageLike;
   /** a promise that resolves once the sign in callback is reached,
    * with any data, e.g. a callback URL
    * @defaults Promise.resolve()
@@ -266,7 +337,7 @@ async function handleConsentPage<T>(context: AutomatedSignInContext<T>): Promise
 }
 
 async function checkSelectorExists(
-  page: Page,
+  page: PageLike,
   selector: string,
 ): Promise<boolean> {
   try {
@@ -277,7 +348,7 @@ async function checkSelectorExists(
   }
 }
 
-async function checkErrorOnPage(page: Page, selector: string): Promise<void> {
+async function checkErrorOnPage(page: PageLike, selector: string): Promise<void> {
   let errMsgText: string | null | undefined;
   try {
     const errMsgElement = page.locator(selector).first();
@@ -351,7 +422,7 @@ export async function launchDefaultAutomationPage(enableSlowNetworkConditions = 
 }
 
 async function cleanup(
-  page: Page,
+  page: PageLike,
   signal: AbortSignal,
   waitForCallbackUrl: Promise<any>,
   doNotKillBrowser = false,

--- a/packages/oidc-signin-tool/src/SignInAutomation.ts
+++ b/packages/oidc-signin-tool/src/SignInAutomation.ts
@@ -107,7 +107,7 @@ interface AutomatedContextBase<T> {
 
   /** whether or not to leave the page open when cleaning up.
    * Useful when the consumer supplies their own page and owns its lifecycle. */
-  doNotClosePage?: boolean;
+  closePage?: boolean;
 }
 
 /** @internal context for automated sign in functions */

--- a/packages/oidc-signin-tool/src/SignInAutomation.ts
+++ b/packages/oidc-signin-tool/src/SignInAutomation.ts
@@ -12,11 +12,7 @@ import { testSelectors } from "./TestSelectors";
  * API that the sign-in automation actually uses. They are declared structurally
  * so that a `Page` from *any* Playwright installation/version satisfies them,
  * without baking this package's exact `@playwright/test` type identity into the
- * public API. A real Playwright `Page` is assignable to `PageLike`.
- *
- * Return types for calls whose results are ignored are widened to
- * `Promise<unknown>` so that Playwright's more specific return types (e.g.
- * `Promise<Response | null>`) remain assignable. */
+ * public API. A real Playwright `Page` is assignable to `PageLike`. */
 
 /**
  * The minimal subset of the Playwright `Locator` API used by the automation.
@@ -59,10 +55,6 @@ export interface RequestLike {
 
 /**
  * The minimal subset of the Playwright `Page` API used by the automation.
- *
- * A real Playwright `Page` satisfies this interface, so you can supply a page
- * created by *your own* Playwright installation/version without being forced
- * onto this package's exact `@playwright/test` types.
  * @alpha
  */
 export interface PageLike {

--- a/packages/oidc-signin-tool/src/SignInAutomation.ts
+++ b/packages/oidc-signin-tool/src/SignInAutomation.ts
@@ -162,7 +162,7 @@ export async function automatedSignIn<T>(
       // eslint-disable-next-line @typescript-eslint/return-await
       return await context.resultFromCallback(await waitForCallback);
   } finally {
-    await cleanup(page, controller.signal, waitForCallback, context.doNotKillBrowser, context.doNotClosePage);
+    await cleanup(page, controller.signal, waitForCallback, context.doNotKillBrowser, context.closePage);
   }
 }
 
@@ -181,7 +181,7 @@ export async function automatedSignOut<T>(
   try {
     await page.goto(context.signOutInitUrl);
   } finally {
-    await cleanup(page, controller.signal, waitForCallback, context.doNotKillBrowser, context.doNotClosePage);
+    await cleanup(page, controller.signal, waitForCallback, context.doNotKillBrowser, context.closePage);
   }
 }
 
@@ -426,13 +426,13 @@ async function cleanup(
   signal: AbortSignal,
   waitForCallbackUrl: Promise<any>,
   doNotKillBrowser = false,
-  doNotClosePage = false,
+  closePage = true,
 ) {
   if (signal.aborted)
     await page.reload();
   await waitForCallbackUrl;
 
-  if (doNotClosePage)
+  if (!closePage)
     return;
 
   await page.close();

--- a/packages/oidc-signin-tool/src/TestBrowserAuthorizationClient.ts
+++ b/packages/oidc-signin-tool/src/TestBrowserAuthorizationClient.ts
@@ -6,13 +6,13 @@ import type { AccessToken } from "@itwin/core-bentley";
 import { BeEvent } from "@itwin/core-bentley";
 import type { AuthorizationClient } from "@itwin/core-common";
 import { OIDCDiscoveryClient } from "@itwin/service-authorization";
-import type { Page } from "@playwright/test";
 import { InMemoryWebStorage, OidcClient, WebStorageStateStore } from "oidc-client-ts";
 import type {
   TestBrowserAuthorizationClientConfiguration,
   TestUserCredentials,
 } from "./TestUsers";
 import * as SignInAutomation from "./SignInAutomation";
+import type { PageLike } from "./SignInAutomation";
 
 /**
  * Options controlling how a token is acquired.
@@ -31,8 +31,13 @@ export interface GetAccessTokenOptions {
    *
    * When omitted, the tool falls back to importing its own `@playwright/test`
    * and launching its own browser.
+   *
+   * Typed as the minimal structural {@link PageLike} rather than Playwright's
+   * concrete `Page` so a page from any Playwright installation/version is
+   * accepted without forcing consumers onto this package's `@playwright/test`
+   * types. A real Playwright `Page` satisfies {@link PageLike}.
    */
-  page?: Page;
+  page?: PageLike;
 }
 
 /**

--- a/packages/oidc-signin-tool/src/TestBrowserAuthorizationClient.ts
+++ b/packages/oidc-signin-tool/src/TestBrowserAuthorizationClient.ts
@@ -6,12 +6,34 @@ import type { AccessToken } from "@itwin/core-bentley";
 import { BeEvent } from "@itwin/core-bentley";
 import type { AuthorizationClient } from "@itwin/core-common";
 import { OIDCDiscoveryClient } from "@itwin/service-authorization";
+import type { Page } from "@playwright/test";
 import { InMemoryWebStorage, OidcClient, WebStorageStateStore } from "oidc-client-ts";
 import type {
   TestBrowserAuthorizationClientConfiguration,
   TestUserCredentials,
 } from "./TestUsers";
 import * as SignInAutomation from "./SignInAutomation";
+
+/**
+ * Options controlling how a token is acquired.
+ * @alpha
+ */
+export interface GetAccessTokenOptions {
+  /**
+   * A Playwright `Page` used to drive the sign-in UI.
+   *
+   * When provided, the tool uses this page instead of dynamically importing its
+   * own copy of `@playwright/test` and launching a browser. Supply this when you
+   * already depend on Playwright to avoid loading two Playwright instances,
+   * which throws a "multiple playwright dependencies active" runtime error.
+   *
+   * The tool does **not** close your page or browser — you own their lifecycle.
+   *
+   * When omitted, the tool falls back to importing its own `@playwright/test`
+   * and launching its own browser.
+   */
+  page?: Page;
+}
 
 /**
  * Implementation of AuthorizationClient used for the iModel.js integration tests.
@@ -69,7 +91,7 @@ export class TestBrowserAuthorizationClient implements AuthorizationClient {
    * The token is refreshed if necessary and possible.
    * @throws [[BentleyError]] If the client was not used to authorize, or there was an authorization error.
    */
-  public async getAccessToken(): Promise<AccessToken> {
+  public async getAccessToken(options?: GetAccessTokenOptions): Promise<AccessToken> {
     if (this.isAuthorized)
       return this._accessToken;
 
@@ -77,7 +99,7 @@ export class TestBrowserAuthorizationClient implements AuthorizationClient {
     let numRetries = 0;
     while (numRetries < 3) {
       try {
-        await this.signIn();
+        await this.signIn(options);
       } catch (err) {
         // eslint-disable-next-line no-console
         console.log("Error signing in", err);
@@ -103,7 +125,7 @@ export class TestBrowserAuthorizationClient implements AuthorizationClient {
     return this._accessToken;
   }
 
-  public async signIn(): Promise<void> {
+  public async signIn(options?: GetAccessTokenOptions): Promise<void> {
     const config = await this._discoveryClient.getConfig();
 
     // eslint-disable-next-line no-console
@@ -128,7 +150,8 @@ export class TestBrowserAuthorizationClient implements AuthorizationClient {
 
     const controller = new AbortController();
 
-    const page = await SignInAutomation.launchDefaultAutomationPage();
+    const consumerOwnsPage = options?.page !== undefined;
+    const page = options?.page ?? await SignInAutomation.launchDefaultAutomationPage();
 
     const oidcConfig = await this._discoveryClient.getConfig();
 
@@ -141,6 +164,11 @@ export class TestBrowserAuthorizationClient implements AuthorizationClient {
         authorizationEndpoint: oidcConfig.authorization_endpoint,
       },
       abortController: controller,
+
+      // when the consumer brings their own page, they own its lifecycle:
+      // leave both the page and the browser open after sign-in
+      doNotKillBrowser: consumerOwnsPage,
+      doNotClosePage: consumerOwnsPage,
 
       // Eventually, we'll get a redirect to the callback url
       // including the params we need to retrieve a token
@@ -176,7 +204,8 @@ export class TestBrowserAuthorizationClient implements AuthorizationClient {
 export async function getTestAccessToken(
   config: TestBrowserAuthorizationClientConfiguration,
   user: TestUserCredentials,
+  options?: GetAccessTokenOptions,
 ): Promise<AccessToken | undefined> {
   const client = new TestBrowserAuthorizationClient(config, user);
-  return client.getAccessToken();
+  return client.getAccessToken(options);
 }

--- a/packages/oidc-signin-tool/src/TestBrowserAuthorizationClient.ts
+++ b/packages/oidc-signin-tool/src/TestBrowserAuthorizationClient.ts
@@ -24,18 +24,11 @@ export interface GetAccessTokenOptions {
    *
    * When provided, the tool uses this page instead of dynamically importing its
    * own copy of `@playwright/test` and launching a browser. Supply this when you
-   * already depend on Playwright to avoid loading two Playwright instances,
-   * which throws a "multiple playwright dependencies active" runtime error.
+   * already depend on Playwright to avoid loading two Playwright instances.
    *
-   * The tool does **not** close your page or browser — you own their lifecycle.
+   * The tool does not close the page or browser, caller is responsible for the page's lifecycle.
    *
-   * When omitted, the tool falls back to importing its own `@playwright/test`
-   * and launching its own browser.
    *
-   * Typed as the minimal structural {@link PageLike} rather than Playwright's
-   * concrete `Page` so a page from any Playwright installation/version is
-   * accepted without forcing consumers onto this package's `@playwright/test`
-   * types. A real Playwright `Page` satisfies {@link PageLike}.
    */
   page?: PageLike;
 }

--- a/packages/oidc-signin-tool/src/TestBrowserAuthorizationClient.ts
+++ b/packages/oidc-signin-tool/src/TestBrowserAuthorizationClient.ts
@@ -166,7 +166,7 @@ export class TestBrowserAuthorizationClient implements AuthorizationClient {
       // when the consumer brings their own page, they own its lifecycle:
       // leave both the page and the browser open after sign-in
       doNotKillBrowser: consumerOwnsPage,
-      doNotClosePage: consumerOwnsPage,
+      closePage: !consumerOwnsPage,
 
       // Eventually, we'll get a redirect to the callback url
       // including the params we need to retrieve a token

--- a/packages/oidc-signin-tool/src/TestUtility.ts
+++ b/packages/oidc-signin-tool/src/TestUtility.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 import type { AccessToken } from "@itwin/core-bentley";
 import { TestBrowserAuthorizationClient } from "./TestBrowserAuthorizationClient";
+import type { GetAccessTokenOptions } from "./TestBrowserAuthorizationClient";
 import type { TestBrowserAuthorizationClientConfiguration, TestUserCredentials } from "./TestUsers";
 import { TestUsers } from "./TestUsers";
 
@@ -47,10 +48,12 @@ export class TestUtility {
    * to signin the user through a headless browser.
    * - Uses the default iModel.js internal OIDC SPA client registration
    * @param user Test user credentials
+   * @param options Optionally supply your own Playwright `page` to avoid
+   * importing a second copy of `@playwright/test`
    * @internal
    */
-  public static async getAccessToken(user: TestUserCredentials): Promise<AccessToken> {
+  public static async getAccessToken(user: TestUserCredentials, options?: GetAccessTokenOptions): Promise<AccessToken> {
     const client = this.getAuthorizationClient(user);
-    return client.getAccessToken();
+    return client.getAccessToken(options);
   }
 }

--- a/packages/oidc-signin-tool/src/TestUtility.ts
+++ b/packages/oidc-signin-tool/src/TestUtility.ts
@@ -48,7 +48,7 @@ export class TestUtility {
    * to signin the user through a headless browser.
    * - Uses the default iModel.js internal OIDC SPA client registration
    * @param user Test user credentials
-   * @param options Optionally supply your own Playwright `page` to avoid
+   * @param options Optionally supply your a Playwright `page` to avoid
    * importing a second copy of `@playwright/test`
    * @internal
    */

--- a/packages/oidc-signin-tool/src/test-integration/customPage.test.ts
+++ b/packages/oidc-signin-tool/src/test-integration/customPage.test.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, test } from "@playwright/test";
+import type { TestBrowserAuthorizationClientConfiguration } from "../index";
+import { getTestAccessToken } from "../TestBrowserAuthorizationClient";
+import { TestUsers } from "../TestUsers";
+import { loadConfig, TestConfigType } from "./loadConfig";
+
+let oidcConfig: TestBrowserAuthorizationClientConfiguration;
+
+test.beforeEach(() => {
+  oidcConfig = loadConfig(TestConfigType.OIDC);
+});
+
+test.describe("Sign in with a caller-provided page (#integration)", () => {
+  test("succeeds and does not close the provided page or browser", async ({ browser }) => {
+    const page = await browser.newPage();
+    try {
+      const token = await getTestAccessToken(oidcConfig, TestUsers.regular, { page });
+
+      // sign-in succeeded
+      expect(token).toBeDefined();
+
+      // the tool must not close/kill a page and browser it did not create
+      expect(page.isClosed()).toBe(false);
+      expect(browser.isConnected()).toBe(true);
+
+      // the provided page is still usable afterwards
+      expect(await page.evaluate(() => 1 + 1)).toBe(2);
+    } finally {
+      await page.close();
+    }
+  });
+});


### PR DESCRIPTION
Closes https://github.com/iTwin/auth-clients/issues/349

Added optional `page` parameter to the methods doing signing. This allows to pass in already loaded `playwright` instance and avoid `oidc-signin-tool` loading its own.

Tested manually in e2e tests and this allows to use different playwright version without overriding `oidc-signin-tool` playwright version. ~~One caveat is that there might by typescript errors when using newer version than one specified `oidc-signin-tool`. This is due `playwright` not following semver and making breaking changes in minor bump. However, everything worked fine as not whole API surface is used by `oidc-signin-tool`.~~ I could successfully pass in Page from different versions of playwright to be used for signin process.