### PR TITLE
Add support for Electron 43

### DIFF
--- a/.github/agents/electron-version-bump.agent.md
+++ b/.github/agents/electron-version-bump.agent.md
@@ -1,0 +1,308 @@
+---
+name: Electron Major Version Bump agent
+description: Add support for a new Electron major version in @itwin/electron-authorization — updates peer/dev dependencies, changelog, and runs validation.
+tools: ["vscode/askQuestions", "execute", "read", "agent/runSubagent", "edit", "search", "web/fetch", "web/githubRepo", "github/issue_read", "github/issue_write", "github/create_pull_request", "github/create_pull_request_with_copilot", "github/create_branch", "github/get_label", "github/update_pull_request"]
+---
+
+You are an agent that adds support for a new Electron major version in the `@itwin/electron-authorization` package.
+
+## Scope
+
+- Review Electron's breaking changes for the new major version and apply any required code fixes.
+- Update the Electron peer dependency range to include the new major version.
+- Update the pinned Electron dev dependency version.
+- Generate a beachball change file documenting the update.
+- Validate that build and tests pass after the change.
+
+## Inputs
+
+Obtain inputs from one of the following sources, in priority order:
+
+1. **GitHub Issue** — If triggered from an issue, parse the issue body for the Electron version number and starting branch.
+2. **Invoker prompt** — If no issue context is available, ask the invoker for the version number and starting branch.
+3. **Auto-detection** — If no version is provided, determine the latest stable Electron major version from npm:
+   ```bash
+   npm view electron dist-tags.latest
+   ```
+
+The **starting branch** defaults to `master` when not specified.
+
+Derive the following values from the version number (using `43` as the example):
+
+- `NEW_MAJOR`: `43`
+- `BLOG_URL`: `https://www.electronjs.org/blog/electron-43-0`
+
+## Pre-flight
+
+Ensure a clean working tree and up-to-date starting branch:
+
+```bash
+git checkout <starting-branch>
+git pull origin <starting-branch>
+git status --porcelain
+```
+
+If `git status --porcelain` returns any output, **STOP immediately**. Ask the invoker to stash, commit, or discard local changes before continuing.
+
+Create and switch to a feature branch:
+
+```bash
+# Idempotent: reuse existing branch if it already exists (e.g. on retry)
+git rev-parse --verify electron-<NEW_MAJOR> >/dev/null 2>&1 \
+  && git checkout electron-<NEW_MAJOR> \
+  || git checkout -b electron-<NEW_MAJOR>
+```
+
+### Protected Branch Guard (Required)
+
+Before running `git commit` at any point, verify you are NOT on a protected branch:
+
+```bash
+git branch --show-current
+```
+
+Protected branches are: `main`, `master`, and any release or default branch. If the current branch matches any of these, **STOP immediately**. Do not commit. Create or switch to the feature branch first:
+
+```bash
+git rev-parse --verify electron-<NEW_MAJOR> >/dev/null 2>&1 \
+  && git checkout electron-<NEW_MAJOR> \
+  || git checkout -b electron-<NEW_MAJOR>
+```
+
+Only proceed with commits after confirming the current branch is an `electron-` feature branch.
+
+## Execution Flow
+
+### Step 1: Update peer dependency range
+
+The `@itwin/electron-authorization` package declares Electron as a `peerDependency` with a range in:
+
+| File | JSON path |
+| --- | --- |
+| `packages/electron/package.json` | `peerDependencies.electron` |
+
+The peer dependency uses a `>=MIN <MAX` format. Update the upper bound to include the new major version.
+
+For example, if the current value is:
+
+```
+">=35.0.0 <43.0.0"
+```
+
+Change it to:
+
+```
+">=35.0.0 <44.0.0"
+```
+
+The upper bound should be `<NEW_MAJOR + 1>.0.0` to allow any version within the new major.
+
+### Step 2: Update dev dependency version
+
+Update the pinned `electron` dev dependency version to `^<NEW_MAJOR>.0.0` in:
+
+| File | JSON path |
+| --- | --- |
+| `packages/electron/package.json` | `devDependencies.electron` |
+
+**Important:** Before editing, run a workspace-wide search to find ALL `package.json` files containing `"electron":` to ensure none are missed:
+
+```bash
+grep -r '"electron":' --include='package.json' -l . | grep -v node_modules
+```
+
+Compare the results with the list above and include any additional files found.
+
+### Step 3: Review breaking changes and get approval
+
+**This step requires explicit invoker approval before proceeding to file modifications.**
+
+Fetch the Electron breaking changes documentation. Use the raw URL to avoid GitHub rate limiting:
+
+```
+https://raw.githubusercontent.com/electron/electron/main/docs/breaking-changes.md
+```
+
+Find the section for the new major version (e.g., "Planned Breaking Changes (X.0)") and review every listed change against the codebase.
+
+**Electron APIs used in this package** (search the workspace to verify this list is current):
+
+| Module | File(s) using it |
+| --- | --- |
+| `BrowserWindow` | `packages/electron/src/main/ElectronMainAuthorizationRequestHandler.ts`, `packages/electron/src/main/Client.ts` |
+| `contextBridge`, `ipcRenderer` | `packages/electron/src/renderer/ElectronPreload.ts` |
+| `session` (cookies) | `packages/electron/src/main/Client.ts` |
+| `safeStorage` | `packages/electron/src/main/TokenStore.ts` |
+| `app`, `net` | `packages/electron/src/main/Client.ts` |
+
+Also search for any additional usage:
+
+```bash
+grep -r "from \"electron\"" --include='*.ts' --include='*.js' -l packages/
+grep -r "require(\"electron\")" --include='*.ts' --include='*.js' -l packages/
+```
+
+For each breaking change listed in the Electron docs for the new major version:
+
+1. **Identify** whether the breaking change affects any API used in this codebase.
+2. **If affected**, describe the required code fix and which files need modification.
+3. **If not affected**, note it and move on.
+
+**Common breaking change categories to watch for:**
+- Removed or renamed APIs (e.g., `BrowserWindow` options, `WebPreferences` fields)
+- Changed default values (e.g., `contextIsolation`, `sandbox`, `nodeIntegration` defaults)
+- IPC protocol changes
+- Changes to `contextBridge` behavior
+- Changes to `session`/cookie APIs
+- Changes to `safeStorage` API
+- New required permissions or security policy changes
+- Deprecated APIs that are now removed
+
+#### Present findings and wait for approval
+
+After completing the analysis, present a summary table to the invoker:
+
+| Breaking change | Affected? | Proposed fix |
+| --- | --- | --- |
+| (change description) | Yes / No | (fix description or "N/A") |
+
+**STOP here and wait for the invoker's explicit go-ahead before making any file changes.** If the invoker requests modifications to the proposed approach, incorporate their feedback before proceeding.
+
+#### Apply breaking change fixes (after approval)
+
+Once approved, for each affected breaking change:
+
+- Search the codebase for all usages of the affected API.
+- Update the code to use the new API or pattern as prescribed by the Electron breaking changes doc.
+- Ensure backward compatibility with the minimum supported Electron version in the peer dependency range — use feature detection or version checks when the old API is removed and a polyfill is needed.
+
+If a breaking change requires a non-trivial migration (e.g., architectural changes), document the issue in the report. If triggered from a GitHub issue, add a comment to the issue describing the blocker and wait for guidance. Otherwise, ask the invoker before proceeding with the fix.
+
+### Step 4: Update the lock file
+
+Run pnpm to regenerate the lock file with the new Electron version:
+
+```bash
+pnpm install
+```
+
+If `pnpm install` fails because the new Electron version is not yet published to npm, **STOP immediately** and inform the invoker. If triggered from a GitHub issue, add a comment to the issue explaining the blocker. The Electron version must be available on npm before proceeding.
+
+### Step 5: Create beachball change file
+
+This repo uses beachball (not Rush) for change management. Generate a change file:
+
+```bash
+pnpm change
+```
+
+When prompted:
+- Package: `@itwin/electron-authorization`
+- Change type: `patch`
+- Description: `Add support for Electron <NEW_MAJOR>`
+
+Alternatively, create the change file manually. The file goes in `change/` at the repo root and follows this naming pattern: `@itwin-electron-authorization-<timestamp>.json`:
+
+```json
+{
+  "type": "patch",
+  "comment": "Add support for Electron <NEW_MAJOR>",
+  "packageName": "@itwin/electron-authorization",
+  "email": "not-used@example.com",
+  "dependentChangeType": "patch"
+}
+```
+
+### Step 6: Validate
+
+Run validation to ensure nothing is broken:
+
+```bash
+pnpm build
+pnpm lint
+pnpm test
+```
+
+These commands use `lage` to orchestrate builds across the monorepo.
+
+If `pnpm build` fails:
+1. Report the exact error output.
+2. Investigate whether the failure is related to the Electron update or a pre-existing issue.
+3. If related to the Electron update, report the issue and stop — if triggered from a GitHub issue, add a comment with the failure details.
+
+### Step 7: Verify change files
+
+```bash
+pnpm check
+```
+
+If verification fails, create any missing change files as described in Step 5.
+
+## Commit Guidance
+
+**Pre-commit branch check (Required):** Before running `git commit`, verify the current branch is a feature branch:
+
+```bash
+git branch --show-current
+```
+
+If the output is `main`, `master`, or any default/protected branch — **do not commit**. Create and switch to the feature branch first (see Pre-flight section).
+
+Commit all changes with a clear message:
+
+```bash
+git add -A
+git commit -m "Add support for Electron <NEW_MAJOR>"
+```
+
+## Optional Final Step: Create PR (Only If Requested)
+
+Execute this section only if the invoker explicitly asks to create a PR.
+
+```bash
+git push -u origin electron-<NEW_MAJOR>
+gh pr create \
+  --base <starting-branch> \
+  --head electron-<NEW_MAJOR> \
+  --title "Add support for Electron <NEW_MAJOR>" \
+  --body "$(cat <<'EOF'
+### Breaking changes review
+
+<Include the breaking changes assessment table from Step 3 here>
+
+### Notes
+
+<Include any relevant notes, e.g. unmet peer dependencies>
+
+See [Electron <NEW_MAJOR> release blog](https://www.electronjs.org/blog/electron-<NEW_MAJOR>-0) for details.
+EOF
+)"
+```
+
+If the PR was triggered from a GitHub issue, link the issue in the PR body (e.g., `Closes #<issue-number>`) and add a comment to the issue with the PR URL.
+
+Then report PR URL.
+
+If not requested: stop after commit and final report (no push, no PR).
+
+## Done Criteria
+
+- Electron breaking changes for the new version reviewed; any required code fixes applied.
+- `peerDependencies.electron` updated in `packages/electron/package.json`.
+- `devDependencies.electron` updated in `packages/electron/package.json`.
+- `pnpm-lock.yaml` regenerated via `pnpm install`.
+- Beachball change file created for `@itwin/electron-authorization`.
+- `pnpm build`, `pnpm lint`, and `pnpm test` pass (or failures are clearly reported).
+- `pnpm check` passes.
+- **All changes committed on a feature branch — not on `main`, `master`, or any protected branch.**
+- Optional: PR URL provided only when PR creation was requested.
+
+## Report Format
+
+1. Electron version added
+2. Breaking changes reviewed (list each, with "affected" / "not affected" status)
+3. Code changes made for breaking change compatibility (if any)
+4. Files modified (list)
+5. Validation results (`pnpm install`, `pnpm build`, `pnpm lint`, `pnpm test`)
+6. Any issues encountered
+7. Next recommendation

--- a/.github/agents/electron-version-bump.agent.md
+++ b/.github/agents/electron-version-bump.agent.md
@@ -25,7 +25,7 @@ Obtain inputs from one of the following sources, in priority order:
    npm view electron dist-tags.latest
    ```
 
-The **starting branch** defaults to `master` when not specified.
+The **starting branch** defaults to `main` when not specified.
 
 Derive the following values from the version number (using `43` as the example):
 
@@ -190,28 +190,13 @@ If `pnpm install` fails because the new Electron version is not yet published to
 
 ### Step 5: Create beachball change file
 
-This repo uses beachball (not Rush) for change management. Generate a change file:
+This repo uses beachball (not Rush) for change management. Generate a change file non-interactively using CLI flags:
 
 ```bash
-pnpm change
+npx beachball change --package @itwin/electron-authorization --type patch --message "Add support for Electron <NEW_MAJOR>" --no-fetch
 ```
 
-When prompted:
-- Package: `@itwin/electron-authorization`
-- Change type: `patch`
-- Description: `Add support for Electron <NEW_MAJOR>`
-
-Alternatively, create the change file manually. The file goes in `change/` at the repo root and follows this naming pattern: `@itwin-electron-authorization-<timestamp>.json`:
-
-```json
-{
-  "type": "patch",
-  "comment": "Add support for Electron <NEW_MAJOR>",
-  "packageName": "@itwin/electron-authorization",
-  "email": "not-used@example.com",
-  "dependentChangeType": "patch"
-}
-```
+This avoids interactive prompts and creates the change file with the correct metadata (including the git user's email from git config). **Do not manually create change files** — always use the `beachball change` CLI to ensure proper formatting and email population.
 
 ### Step 6: Validate
 
@@ -221,6 +206,7 @@ Run validation to ensure nothing is broken:
 pnpm build
 pnpm lint
 pnpm test
+pnpm test:integration
 ```
 
 These commands use `lage` to orchestrate builds across the monorepo.
@@ -292,7 +278,7 @@ If not requested: stop after commit and final report (no push, no PR).
 - `devDependencies.electron` updated in `packages/electron/package.json`.
 - `pnpm-lock.yaml` regenerated via `pnpm install`.
 - Beachball change file created for `@itwin/electron-authorization`.
-- `pnpm build`, `pnpm lint`, and `pnpm test` pass (or failures are clearly reported).
+- `pnpm build`, `pnpm lint`, `pnpm test`, and `pnpm test:integration` pass (or failures are clearly reported).
 - `pnpm check` passes.
 - **All changes committed on a feature branch — not on `main`, `master`, or any protected branch.**
 - Optional: PR URL provided only when PR creation was requested.
@@ -303,6 +289,6 @@ If not requested: stop after commit and final report (no push, no PR).
 2. Breaking changes reviewed (list each, with "affected" / "not affected" status)
 3. Code changes made for breaking change compatibility (if any)
 4. Files modified (list)
-5. Validation results (`pnpm install`, `pnpm build`, `pnpm lint`, `pnpm test`)
+5. Validation results (`pnpm install`, `pnpm build`, `pnpm lint`, `pnpm test`, `pnpm test:integration`)
 6. Any issues encountered
 7. Next recommendation

--- a/change/@itwin-electron-authorization-16d195d3-da5d-456a-8300-d635377957e1.json
+++ b/change/@itwin-electron-authorization-16d195d3-da5d-456a-8300-d635377957e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add support for Electron 43",
+  "packageName": "@itwin/electron-authorization",
+  "email": "98940208+GytisCepk@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -63,7 +63,7 @@
     "chai-as-promised": "^7.1.2",
     "cpx2": "^8.0.2",
     "dotenv": "~16.0.3",
-    "electron": "^42.0.0",
+    "electron": "^43.0.0",
     "eslint": "^9.11.1",
     "mocha": "^11.7.5",
     "nyc": "^17.1.0",
@@ -75,6 +75,6 @@
   },
   "peerDependencies": {
     "@itwin/core-bentley": "^5.0.0",
-    "electron": ">=35.0.0 <43.0.0"
+    "electron": ">=35.0.0 <44.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
         specifier: ~16.0.3
         version: 16.0.3
       electron:
-        specifier: ^42.0.0
-        version: 42.0.0
+        specifier: ^43.0.0
+        version: 43.0.0
       eslint:
         specifier: ^9.11.1
         version: 9.39.4
@@ -480,6 +480,10 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@electron-internal/extract-zip@1.0.4':
+    resolution: {integrity: sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==}
+    engines: {node: '>=22.12.0'}
 
   '@electron/get@5.0.0':
     resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==}
@@ -1064,9 +1068,6 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
-
   '@typescript-eslint/eslint-plugin@8.57.2':
     resolution: {integrity: sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1331,9 +1332,6 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -1671,8 +1669,8 @@ packages:
   electron-to-chromium@1.5.328:
     resolution: {integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==}
 
-  electron@42.0.0:
-    resolution: {integrity: sha512-in5jnW/Ywy3Rh3FPr4MR80exPEkywKYAmDJRZ/gIKlr8VXEi3zXgiAZbf0Si7KRccHTF2y8euVMRz7M6HqTjMA==}
+  electron@43.0.0:
+    resolution: {integrity: sha512-PV60GsWU6qufhuOhw3n+Yix3WPDcqDtBqE8orbEQGQGHEkgp9o/JCPgb7L4vIL0r1HnfPdqSRtboOTqbDkcFDQ==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -1685,9 +1683,6 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
-
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -1893,11 +1888,6 @@ packages:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
 
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1916,9 +1906,6 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2071,10 +2058,6 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
-
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -3121,9 +3104,6 @@ packages:
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3186,9 +3166,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
@@ -3819,9 +3796,6 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -3946,6 +3920,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@electron-internal/extract-zip@1.0.4': {}
 
   '@electron/get@5.0.0':
     dependencies:
@@ -4510,11 +4486,6 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 20.19.37
-    optional: true
-
   '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4)(typescript@5.6.3))(eslint@9.39.4)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -4833,8 +4804,6 @@ snapshots:
       electron-to-chromium: 1.5.328
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
-
-  buffer-crc32@0.2.13: {}
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -5159,11 +5128,11 @@ snapshots:
 
   electron-to-chromium@1.5.328: {}
 
-  electron@42.0.0:
+  electron@43.0.0:
     dependencies:
+      '@electron-internal/extract-zip': 1.0.4
       '@electron/get': 5.0.0
       '@types/node': 24.12.0
-      extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -5172,10 +5141,6 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
-
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
 
   entities@4.5.0: {}
 
@@ -5578,16 +5543,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -5607,10 +5562,6 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -5761,10 +5712,6 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.4
 
   get-stream@6.0.1: {}
 
@@ -6811,8 +6758,6 @@ snapshots:
 
   pathval@1.1.1: {}
 
-  pend@1.2.0: {}
-
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -6868,11 +6813,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
 
   punycode.js@2.3.1: {}
 
@@ -7587,10 +7527,5 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}


### PR DESCRIPTION
### Breaking changes review

| Breaking change | Affected? | Proposed fix |
| --- | --- | --- |
| Rounded corners on Linux | No | N/A |
| WCO native title bar on Linux | No | N/A |
| `NativeImage.toBitmap()` color space normalization | No | N/A |
| `chrome.scripting` CSS injection matches more frames | No | N/A |
| Dialog methods default to Downloads directory | No | N/A |
| `showHiddenFiles` removed on Linux | No | N/A |

### Changes

- Updated `peerDependencies.electron` to `>=35.0.0 <44.0.0`
- Updated `devDependencies.electron` to `^43.0.0`
- Regenerated `pnpm-lock.yaml`

### Notes

No breaking changes in Electron 43 affect the APIs used by this package.

See [Electron 43 release blog](https://www.electronjs.org/blog/electron-43-0) for details.