### PR TITLE
Cache OIDC configuration for Electron client

### DIFF
--- a/change/@itwin-electron-authorization-d5555d42-6185-4381-8197-554686a03298.json
+++ b/change/@itwin-electron-authorization-d5555d42-6185-4381-8197-554686a03298.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Cache OIDC configuration when using Electron client",
+  "packageName": "@itwin/electron-authorization",
+  "email": "alex.dunae@bentley.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-electron-authorization-d5555d42-6185-4381-8197-554686a03298.json
+++ b/change/@itwin-electron-authorization-d5555d42-6185-4381-8197-554686a03298.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Cache OIDC configuration when using the Electron and node-cli clients",
+  "comment": "Cache OIDC configuration",
   "packageName": "@itwin/electron-authorization",
   "email": "alex.dunae@bentley.com",
   "dependentChangeType": "patch"

--- a/change/@itwin-electron-authorization-d5555d42-6185-4381-8197-554686a03298.json
+++ b/change/@itwin-electron-authorization-d5555d42-6185-4381-8197-554686a03298.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Cache OIDC configuration when using Electron client",
+  "comment": "Cache OIDC configuration when using the Electron and node-cli clients",
   "packageName": "@itwin/electron-authorization",
   "email": "alex.dunae@bentley.com",
   "dependentChangeType": "patch"

--- a/change/@itwin-node-cli-authorization-9c9f19d0-388e-43b5-acf6-46ef01655862.json
+++ b/change/@itwin-node-cli-authorization-9c9f19d0-388e-43b5-acf6-46ef01655862.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Cache OIDC configuration when using Electron client",
+  "comment": "Cache OIDC configuration",
   "packageName": "@itwin/node-cli-authorization",
   "email": "alex.dunae@bentley.com",
   "dependentChangeType": "patch"

--- a/change/@itwin-node-cli-authorization-9c9f19d0-388e-43b5-acf6-46ef01655862.json
+++ b/change/@itwin-node-cli-authorization-9c9f19d0-388e-43b5-acf6-46ef01655862.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Cache OIDC configuration when using Electron client",
+  "packageName": "@itwin/node-cli-authorization",
+  "email": "alex.dunae@bentley.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -134,3 +134,11 @@ The `redirectUris` property is an array of strings that represent the URIs that 
 - `http://localhost:31234/signin-callback`
 - `http://localhost:41234/signin-callback`
 - `http://localhost:51234/signin-callback`
+
+## Manually verify authorization
+
+Run the interactive authorization flow against a registered Native application:
+
+```sh
+IMJS_OIDC_CLIENT_ID=native-... IMJS_OIDC_ISSUER_URL=https://qa-ims.bentley.com pnpm --filter @itwin/electron-authorization verify:flow
+```

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -29,6 +29,7 @@
     "test:integration:start": "pnpm test:integration:build && electron dist/integration-test/test-app/index.js",
     "test:integration:build": "pnpm test:integration:vite && tsc -p ./src/integration-test/",
     "test:integration:vite": "vite build",
+    "verify:flow": "pnpm build && electron scripts/verify-flow.cjs",
     "pack": "npm pack",
     "rebuild": "npm run clean && npm run build"
   },

--- a/packages/electron/scripts/verify-flow.cjs
+++ b/packages/electron/scripts/verify-flow.cjs
@@ -1,0 +1,56 @@
+// Run from the repository root:
+// pnpm --filter @itwin/electron-authorization build
+// IMJS_OIDC_CLIENT_ID=native-... IMJS_OIDC_ISSUER_URL=https://qa-ims.bentley.com pnpm --filter @itwin/electron-authorization exec electron scripts/verify-flow.cjs
+
+const os = require("node:os");
+const path = require("node:path");
+const { Logger, LogLevel } = require("@itwin/core-bentley");
+const { app } = require("electron");
+const { ElectronMainAuthorization } = require("../lib/cjs/ElectronMain");
+const { electronAuthLoggerCategory } = require("../lib/cjs/common/constants");
+
+Logger.initializeToConsole();
+Logger.setLevel(electronAuthLoggerCategory, LogLevel.Trace);
+
+const clientId = process.env.IMJS_OIDC_CLIENT_ID;
+if (!clientId) {
+  console.error(
+    "Set IMJS_OIDC_CLIENT_ID to your Native application client ID.",
+  );
+  process.exitCode = 1;
+  return;
+}
+
+const issuerUrl = process.env.IMJS_OIDC_ISSUER_URL ?? "https://ims.bentley.com";
+const redirectUri =
+  process.env.IMJS_OIDC_REDIRECT_URI ?? "http://localhost:3000/signin-callback";
+const scopes = process.env.IMJS_OIDC_SCOPES ?? "itwin-platform";
+const tokenStorePath =
+  process.env.IMJS_AUTH_CACHE_DIR ??
+  path.join(os.tmpdir(), "itwin-auth-clients", "electron-flow");
+
+async function main() {
+  await app.whenReady();
+  console.log(`Cache: ${tokenStorePath}`);
+
+  const client = new ElectronMainAuthorization({
+    clientId,
+    issuerUrl,
+    redirectUris: [redirectUri],
+    scopes,
+    tokenStorePath,
+  });
+
+  await client.signIn();
+  const accessToken = await client.getAccessToken();
+
+  if (!accessToken.startsWith("Bearer "))
+    throw new Error("Authorization completed without a bearer token");
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => app.quit());

--- a/packages/electron/src/common/constants.ts
+++ b/packages/electron/src/common/constants.ts
@@ -3,6 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+/** @packageDocumentation
+ * @module Main
+ */
+
 /**
  * Refresh token 10 minutes before real expiration time (by default)
  * @internal

--- a/packages/electron/src/integration-test/integration.test.ts
+++ b/packages/electron/src/integration-test/integration.test.ts
@@ -104,17 +104,18 @@ test("buttons exist", async () => {
 test("sign in successful", async ({ browser }) => {
   const page = await browser.newPage();
   await testHelper.checkStatus(electronPage, false);
+  const urlPromise = getUrl(electronApp);
   await testHelper.clickSignIn(electronPage);
-  const url = await getUrl(electronApp);
-  await testHelper.signIn(page, url);
+  await testHelper.signIn(page, await urlPromise);
   await testHelper.checkStatus(electronPage, true);
   await page.close();
 });
 
 test("sign out successful", async ({ browser }) => {
   const page = await browser.newPage();
+  const urlPromise = getUrl(electronApp);
   await testHelper.clickSignIn(electronPage);
-  await testHelper.signIn(page, await getUrl(electronApp));
+  await testHelper.signIn(page, await urlPromise);
   await testHelper.checkStatus(electronPage, true);
   await testHelper.clickSignOut(electronPage);
   await testHelper.checkStatus(electronPage, false);
@@ -123,8 +124,9 @@ test("sign out successful", async ({ browser }) => {
 
 test("when scopes change, sign in is required", async ({ browser }) => {
   const page = await browser.newPage();
+  const urlPromise = getUrl(electronApp);
   await testHelper.clickSignIn(electronPage);
-  await testHelper.signIn(page, await getUrl(electronApp));
+  await testHelper.signIn(page, await urlPromise);
   await testHelper.checkStatus(electronPage, true);
 
   // Admittedly this is cheating: no user would interact
@@ -142,9 +144,9 @@ test("handles multiple instances with different channelClientPrefix", async ({
   await testHelper.checkStatus(electronPage, false);
   await testHelper.checkOtherStatus(electronPage, false);
 
+  const urlPromise = getUrl(electronApp);
   await testHelper.clickSignIn(electronPage);
-  const url = await getUrl(electronApp);
-  await testHelper.signIn(page, url);
+  await testHelper.signIn(page, await urlPromise);
   await page.close();
 
   // only the default auth client should be signed in
@@ -153,9 +155,9 @@ test("handles multiple instances with different channelClientPrefix", async ({
 
   // Now sign in with the other auth client
   const otherPage = await browser.newPage();
+  const otherUrlPromise = getUrl(electronApp);
   await testHelper.clickOtherSignIn(electronPage);
-  const otherUrl = await getUrl(electronApp);
-  await testHelper.signIn(otherPage, otherUrl);
+  await testHelper.signIn(otherPage, await otherUrlPromise);
   await otherPage.close();
 
   // both auth clients should be signed in

--- a/packages/electron/src/main/Client.ts
+++ b/packages/electron/src/main/Client.ts
@@ -43,6 +43,7 @@ import * as electron from "electron";
 import { defaultExpiryBufferInSeconds } from "../common/constants.js";
 import type { IpcChannelNames } from "../common/IpcChannelNames.js";
 import { getIpcChannelNames, getPrefixedClientId } from "../common/IpcChannelNames.js";
+import { OidcDiscoveryCache } from "./OidcDiscoveryCache.js";
 const loggerCategory = "electron-auth";
 
 /**
@@ -153,6 +154,7 @@ export class ElectronMainAuthorization implements AuthorizationClient {
   private _configuration: AuthorizationServiceConfiguration | undefined;
   private _refreshToken: string | undefined;
   private _refreshTokenStore: RefreshTokenStore;
+  private _oidcDiscoveryCache: OidcDiscoveryCache;
   private _expiresAt?: Date;
   private _extras?: AuthenticationOptions;
 
@@ -209,6 +211,10 @@ export class ElectronMainAuthorization implements AuthorizationClient {
     const configFileName = `iTwinJs_${clientIdWithPrefix}`;
     const appStorageKey = `${configFileName}:${this._issuerUrl}`;
     this._refreshTokenStore = new RefreshTokenStore(configFileName, appStorageKey, config.tokenStorePath);
+    this._oidcDiscoveryCache = new OidcDiscoveryCache(
+      this._issuerUrl,
+      config.tokenStorePath,
+    );
   }
 
   /**
@@ -351,19 +357,8 @@ export class ElectronMainAuthorization implements AuthorizationClient {
    *   (ii) an interactive signin that requires user input.
    */
   public async signIn(): Promise<void> {
-    if (!this._configuration) {
-      const tokenRequestor = new NodeRequestor(); // the Node.js based HTTP client
-      this._configuration =
-        await AuthorizationServiceConfiguration.fetchFromIssuer(
-          this._issuerUrl,
-          tokenRequestor,
-        );
-      Logger.logTrace(
-        loggerCategory,
-        "Initialized service configuration",
-        () => ({ configuration: this._configuration }),
-      );
-    }
+    await this.initializeConfiguration();
+    assert(!!this._configuration);
 
     // Attempt to load the access token from store
     const token = await this.loadAccessToken();
@@ -469,25 +464,24 @@ export class ElectronMainAuthorization implements AuthorizationClient {
    * Attempts a silent sign in with the authorization provider
    */
   public async signInSilent(): Promise<void> {
-    if (!this._configuration) {
-      const tokenRequestor = new NodeRequestor(); // the Node.js based HTTP client
-      this._configuration =
-        await AuthorizationServiceConfiguration.fetchFromIssuer(
-          this._issuerUrl,
-          tokenRequestor,
-        );
-      Logger.logTrace(
-        loggerCategory,
-        "Initialized service configuration",
-        () => ({ configuration: this._configuration }),
-      );
-    }
+    await this.initializeConfiguration();
     try {
       // Attempt to load the access token from store
       await this.loadAccessToken();
     } catch (error: any) {
       Logger.logError(loggerCategory, error.message);
     }
+  }
+
+  private async initializeConfiguration(): Promise<void> {
+    if (this._configuration) return;
+
+    this._configuration = await this._oidcDiscoveryCache.getConfiguration();
+    Logger.logTrace(
+      loggerCategory,
+      "Initialized service configuration",
+      () => ({ configuration: this._configuration }),
+    );
   }
 
   private async _onAuthorizationResponse(

--- a/packages/electron/src/main/Client.ts
+++ b/packages/electron/src/main/Client.ts
@@ -18,6 +18,7 @@ import type {
   AuthorizationError,
   AuthorizationRequestJson,
   AuthorizationResponse,
+  AuthorizationServiceConfiguration,
   RevokeTokenRequestJson,
   StringMap,
   TokenRequestHandler,
@@ -27,7 +28,6 @@ import type {
 import {
   AuthorizationNotifier,
   AuthorizationRequest,
-  AuthorizationServiceConfiguration,
   BaseTokenRequestHandler,
   GRANT_TYPE_AUTHORIZATION_CODE,
   GRANT_TYPE_REFRESH_TOKEN,

--- a/packages/electron/src/main/Client.ts
+++ b/packages/electron/src/main/Client.ts
@@ -45,10 +45,7 @@ import {
   electronAuthLoggerCategory as loggerCategory,
 } from "../common/constants.js";
 import type { IpcChannelNames } from "../common/IpcChannelNames.js";
-import {
-  getIpcChannelNames,
-  getPrefixedClientId,
-} from "../common/IpcChannelNames.js";
+import { getIpcChannelNames, getPrefixedClientId } from "../common/IpcChannelNames.js";
 import { OidcDiscoveryCache } from "./OidcDiscoveryCache.js";
 
 /**

--- a/packages/electron/src/main/Client.ts
+++ b/packages/electron/src/main/Client.ts
@@ -478,11 +478,7 @@ export class ElectronMainAuthorization implements AuthorizationClient {
     if (this._configuration) return this._configuration;
 
     this._configuration = await this._oidcDiscoveryCache.getConfiguration();
-    Logger.logTrace(
-      loggerCategory,
-      "Initialized service configuration",
-      () => ({ configuration: this._configuration }),
-    );
+    Logger.logTrace(loggerCategory, "Initialized service configuration");
     return this._configuration;
   }
 

--- a/packages/electron/src/main/Client.ts
+++ b/packages/electron/src/main/Client.ts
@@ -40,11 +40,16 @@ import { ElectronMainAuthorizationRequestHandler } from "./ElectronMainAuthoriza
 import { RefreshTokenStore } from "./TokenStore.js";
 import { LoopbackWebServer } from "./LoopbackWebServer.js";
 import * as electron from "electron";
-import { defaultExpiryBufferInSeconds } from "../common/constants.js";
+import {
+  defaultExpiryBufferInSeconds,
+  electronAuthLoggerCategory as loggerCategory,
+} from "../common/constants.js";
 import type { IpcChannelNames } from "../common/IpcChannelNames.js";
-import { getIpcChannelNames, getPrefixedClientId } from "../common/IpcChannelNames.js";
+import {
+  getIpcChannelNames,
+  getPrefixedClientId,
+} from "../common/IpcChannelNames.js";
 import { OidcDiscoveryCache } from "./OidcDiscoveryCache.js";
-const loggerCategory = "electron-auth";
 
 /**
  * - "none" - The Authorization Server MUST NOT display any authentication or consent user interface pages.

--- a/packages/electron/src/main/Client.ts
+++ b/packages/electron/src/main/Client.ts
@@ -357,8 +357,7 @@ export class ElectronMainAuthorization implements AuthorizationClient {
    *   (ii) an interactive signin that requires user input.
    */
   public async signIn(): Promise<void> {
-    await this.initializeConfiguration();
-    assert(!!this._configuration);
+    const configuration = await this.initializeConfiguration();
 
     // Attempt to load the access token from store
     const token = await this.loadAccessToken();
@@ -453,7 +452,7 @@ export class ElectronMainAuthorization implements AuthorizationClient {
 
     // Start the signin
     await authorizationHandler.performAuthorizationRequest(
-      this._configuration,
+      configuration,
       authorizationRequest,
     );
 
@@ -473,8 +472,8 @@ export class ElectronMainAuthorization implements AuthorizationClient {
     }
   }
 
-  private async initializeConfiguration(): Promise<void> {
-    if (this._configuration) return;
+  private async initializeConfiguration(): Promise<AuthorizationServiceConfiguration> {
+    if (this._configuration) return this._configuration;
 
     this._configuration = await this._oidcDiscoveryCache.getConfiguration();
     Logger.logTrace(
@@ -482,6 +481,7 @@ export class ElectronMainAuthorization implements AuthorizationClient {
       "Initialized service configuration",
       () => ({ configuration: this._configuration }),
     );
+    return this._configuration;
   }
 
   private async _onAuthorizationResponse(

--- a/packages/electron/src/main/ElectronMainAuthorizationRequestHandler.ts
+++ b/packages/electron/src/main/ElectronMainAuthorizationRequestHandler.ts
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 // Code based on the blog article @ https://authguidance.com
 
 import { Logger } from "@itwin/core-bentley";
@@ -13,10 +13,10 @@ import {
   AuthorizationError, AuthorizationRequestHandler, AuthorizationResponse, BasicQueryStringUtils,
 } from "@openid/appauth";
 import { NodeCrypto } from "@openid/appauth/built/node_support";
+import { electronAuthLoggerCategory } from "../common/constants.js";
 import type { ElectronAuthorizationEvents } from "./Events.js";
 import { shell } from "electron";
 
-const electronAuthLoggerCategory = "electron-auth";
 /**
  * Utility to setup a local web server that listens to authorization responses to the browser and make the necessary redirections
  * @internal

--- a/packages/electron/src/main/LoopbackWebServer.ts
+++ b/packages/electron/src/main/LoopbackWebServer.ts
@@ -8,9 +8,9 @@ import * as Http from "http";
 import * as path from "path";
 import { readFileSync } from "fs";
 import type { AuthorizationErrorJson, AuthorizationResponseJson } from "@openid/appauth";
+import { electronAuthLoggerCategory as loggerCategory } from "../common/constants.js";
 import type { ElectronAuthorizationEvents } from "./Events.js";
 import { assert, Logger } from "@itwin/core-bentley";
-const loggerCategory = "electron-auth";
 
 type StateEventsPair = [string, ElectronAuthorizationEvents];
 

--- a/packages/electron/src/main/OidcDiscoveryCache.ts
+++ b/packages/electron/src/main/OidcDiscoveryCache.ts
@@ -1,0 +1,193 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { AuthorizationServiceConfigurationJson } from "@openid/appauth";
+import { AuthorizationServiceConfiguration } from "@openid/appauth";
+import { safeStorage } from "electron";
+// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-var-requires
+const Store = require("electron-store"); // eslint-disable-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+
+const cacheVersion = 1;
+const maximumCacheAgeSeconds = 24 * 60 * 60;
+
+interface CachedDiscoveryConfiguration {
+  version: typeof cacheVersion;
+  issuer: string;
+  expiresAt: number;
+  configuration: AuthorizationServiceConfigurationJson;
+}
+
+interface DiscoveryDocument extends AuthorizationServiceConfigurationJson {
+  issuer: string;
+}
+
+/** Persistently caches validated OIDC discovery metadata. */
+export class OidcDiscoveryCache {
+  private readonly _issuer: string;
+  private readonly _store: typeof Store;
+  private readonly _cacheKey: string;
+
+  public constructor(issuer: string, dir?: string) {
+    this._issuer = issuer;
+    this._cacheKey = encodeURIComponent(issuer);
+    this._store = new Store({
+      name: "iTwinJs_oidcDiscoveryCache",
+      encryptionKey: "iTwin",
+      cwd: dir ?? null,
+    });
+  }
+
+  public async getConfiguration(): Promise<AuthorizationServiceConfiguration> {
+    const cached = await this.load();
+    if (cached)
+      return new AuthorizationServiceConfiguration(cached);
+
+    const response = await fetch(
+      `${this._issuer}/.well-known/openid-configuration`,
+      {
+        headers: { accept: "application/json" },
+      },
+    );
+    if (!response.ok)
+      throw new Error(
+        `Failed to retrieve OpenID configuration from authority: ${response.status}`,
+      );
+
+    const document = (await response.json()) as DiscoveryDocument;
+    this.validate(document);
+
+    const configuration = new AuthorizationServiceConfiguration(document);
+    const expiresAt = this.getExpiration(response.headers);
+    if (expiresAt)
+      await this.save({
+        version: cacheVersion,
+        issuer: this._issuer,
+        expiresAt,
+        configuration: configuration.toJson(),
+      });
+
+    return configuration;
+  }
+
+  private async load(): Promise<AuthorizationServiceConfigurationJson | undefined> {
+    if (!this._store.has(this._cacheKey))
+      return undefined;
+
+    try {
+      const encrypted = this._store.get(this._cacheKey) as Buffer;
+      const cached = JSON.parse(
+        await this.decrypt(encrypted),
+      ) as CachedDiscoveryConfiguration;
+      const maximumExpiration = Date.now() + maximumCacheAgeSeconds * 1000;
+      if (
+        cached.version !== cacheVersion ||
+        cached.issuer !== this._issuer ||
+        typeof cached.expiresAt !== "number" ||
+        !Number.isFinite(cached.expiresAt) ||
+        cached.expiresAt <= Date.now() ||
+        cached.expiresAt > maximumExpiration
+      ) {
+        this._store.delete(this._cacheKey);
+        return undefined;
+      }
+
+      this.validate({ issuer: cached.issuer, ...cached.configuration });
+      return cached.configuration;
+    } catch {
+      this._store.delete(this._cacheKey);
+      return undefined;
+    }
+  }
+
+  private async save(cached: CachedDiscoveryConfiguration): Promise<void> {
+    try {
+      this._store.set(
+        this._cacheKey,
+        await this.encrypt(JSON.stringify(cached)),
+      );
+    } catch {
+      // Discovery caching is an optimization; failure to persist must not prevent authorization.
+    }
+  }
+
+  private getExpiration(headers: Headers): number | undefined {
+    const cacheControl = headers.get("cache-control");
+    if (
+      !cacheControl ||
+      /(?:^|,)\s*(?:no-store|no-cache)\s*(?:,|$)/i.test(cacheControl)
+    )
+      return undefined;
+
+    const maxAgeMatch = /(?:^|,)\s*max-age\s*=\s*"?(\d+)"?/i.exec(cacheControl);
+    if (!maxAgeMatch)
+      return undefined;
+
+    const ageHeader = Number.parseInt(headers.get("age") ?? "0", 10);
+    const responseDate = Date.parse(headers.get("date") ?? "");
+    const apparentAge = Number.isFinite(responseDate)
+      ? Math.max(0, (Date.now() - responseDate) / 1000)
+      : 0;
+    const age = Math.max(
+      Number.isFinite(ageHeader) ? ageHeader : 0,
+      apparentAge,
+    );
+    const maxAge = Math.min(
+      Number.parseInt(maxAgeMatch[1], 10),
+      maximumCacheAgeSeconds,
+    );
+    const remainingAge = Math.max(0, maxAge - age);
+    return remainingAge > 0 ? Date.now() + remainingAge * 1000 : undefined;
+  }
+
+  private validate(document: DiscoveryDocument): void {
+    if (document.issuer !== this._issuer)
+      throw new Error(
+        "OIDC discovery response issuer does not match the configured issuer",
+      );
+
+    for (const [name, endpoint] of [
+      ["authorization_endpoint", document.authorization_endpoint],
+      ["token_endpoint", document.token_endpoint],
+      ["revocation_endpoint", document.revocation_endpoint],
+    ]) {
+      if (typeof endpoint !== "string" || endpoint.length === 0)
+        throw new Error(`OIDC discovery response is missing ${name}`);
+    }
+
+    const issuer = new URL(this._issuer);
+    if (issuer.protocol !== "https:")
+      throw new Error("OIDC issuer must use HTTPS");
+
+    for (const endpoint of [
+      document.authorization_endpoint,
+      document.token_endpoint,
+      document.revocation_endpoint,
+      document.end_session_endpoint,
+      document.userinfo_endpoint,
+    ]) {
+      if (!endpoint)
+        continue;
+
+      const endpointUrl = new URL(endpoint);
+      if (endpointUrl.protocol !== "https:")
+        throw new Error("OIDC endpoints must use HTTPS");
+      if (
+        issuer.hostname.endsWith(".bentley.com") &&
+        endpointUrl.origin !== issuer.origin
+      )
+        throw new Error(
+          "Bentley OIDC endpoints must use the configured issuer origin",
+        );
+    }
+  }
+
+  private async encrypt(value: string): Promise<Buffer> {
+    return safeStorage.encryptString(value);
+  }
+
+  private async decrypt(value: Buffer): Promise<string> {
+    return safeStorage.decryptString(Buffer.from(value));
+  }
+}

--- a/packages/electron/src/main/OidcDiscoveryCache.ts
+++ b/packages/electron/src/main/OidcDiscoveryCache.ts
@@ -3,9 +3,11 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import { Logger } from "@itwin/core-bentley";
 import type { AuthorizationServiceConfigurationJson } from "@openid/appauth";
 import { AuthorizationServiceConfiguration } from "@openid/appauth";
 import { safeStorage } from "electron";
+import { electronAuthLoggerCategory } from "../common/constants.js";
 const Store = require("electron-store"); // eslint-disable-line @typescript-eslint/no-require-imports, @typescript-eslint/naming-convention
 
 const cacheVersion = 1;
@@ -79,15 +81,26 @@ export class OidcDiscoveryCache {
       const cached = JSON.parse(
         await this.decrypt(encrypted),
       ) as CachedDiscoveryConfiguration;
-      if (
-        cached.version !== cacheVersion ||
-        isCachedExpired(cached.expiresAt)
-      ) {
+      if (cached.version !== cacheVersion) {
+        this._store.delete(this._cacheKey);
+        return undefined;
+      }
+      if (isCachedExpired(cached.expiresAt)) {
+        Logger.logTrace(
+          electronAuthLoggerCategory,
+          "Cached OIDC configuration expired",
+          () => ({ issuer: this._issuer, expiresAt: cached.expiresAt }),
+        );
         this._store.delete(this._cacheKey);
         return undefined;
       }
 
       this.validate({ issuer: cached.issuer, ...cached.configuration });
+      Logger.logTrace(
+        electronAuthLoggerCategory,
+        "Using cached OIDC configuration",
+        () => ({ issuer: this._issuer, expiresAt: cached.expiresAt }),
+      );
       return cached.configuration;
     } catch {
       this._store.delete(this._cacheKey);

--- a/packages/electron/src/main/OidcDiscoveryCache.ts
+++ b/packages/electron/src/main/OidcDiscoveryCache.ts
@@ -69,9 +69,10 @@ export class OidcDiscoveryCache {
     return configuration;
   }
 
-  private async load(): Promise<AuthorizationServiceConfigurationJson | undefined> {
-    if (!this._store.has(this._cacheKey))
-      return undefined;
+  private async load(): Promise<
+    AuthorizationServiceConfigurationJson | undefined
+  > {
+    if (!this._store.has(this._cacheKey)) return undefined;
 
     try {
       const encrypted = this._store.get(this._cacheKey) as Buffer;
@@ -126,7 +127,6 @@ export class OidcDiscoveryCache {
       maximumCacheAgeSeconds,
     );
     return maxAge > 0 ? Date.now() + maxAge * 1000 : undefined;
-    return remainingAge > 0 ? Date.now() + remainingAge * 1000 : undefined;
   }
 
   private validate(document: DiscoveryDocument): void {
@@ -155,18 +155,11 @@ export class OidcDiscoveryCache {
       document.end_session_endpoint,
       document.userinfo_endpoint,
     ]) {
-      if (!endpoint)
-        continue;
+      if (!endpoint) continue;
 
-      const endpointUrl = new URL(endpoint);
-      if (endpointUrl.protocol !== "https:")
-        throw new Error("OIDC endpoints must use HTTPS");
-      if (
-        issuer.hostname.endsWith(".bentley.com") &&
-        endpointUrl.origin !== issuer.origin
-      )
+      if (!isValidEndpointUrl(endpoint, issuer))
         throw new Error(
-          "Bentley OIDC endpoints must use the configured issuer origin",
+          `OIDC endpoints must use HTTPS and Bentley endpoints must use the configured issuer origin: issuer=${issuer}, endpoint=${endpoint}`,
         );
     }
   }
@@ -177,5 +170,18 @@ export class OidcDiscoveryCache {
 
   private async decrypt(value: Buffer): Promise<string> {
     return safeStorage.decryptString(Buffer.from(value));
+  }
+}
+
+function isValidEndpointUrl(endpoint: string, issuer: URL): boolean {
+  try {
+    const endpointUrl = new URL(endpoint);
+    return (
+      endpointUrl.protocol === "https:" &&
+      (!issuer.hostname.endsWith(".bentley.com") ||
+        endpointUrl.origin === issuer.origin)
+    );
+  } catch {
+    return false;
   }
 }

--- a/packages/electron/src/main/OidcDiscoveryCache.ts
+++ b/packages/electron/src/main/OidcDiscoveryCache.ts
@@ -3,6 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+/** @packageDocumentation
+ * @module Main
+ */
+
 import { Logger } from "@itwin/core-bentley";
 import type { AuthorizationServiceConfigurationJson } from "@openid/appauth";
 import { AuthorizationServiceConfiguration } from "@openid/appauth";

--- a/packages/electron/src/main/OidcDiscoveryCache.ts
+++ b/packages/electron/src/main/OidcDiscoveryCache.ts
@@ -40,8 +40,7 @@ export class OidcDiscoveryCache {
 
   public async getConfiguration(): Promise<AuthorizationServiceConfiguration> {
     const cached = await this.load();
-    if (cached)
-      return new AuthorizationServiceConfiguration(cached);
+    if (cached) return new AuthorizationServiceConfiguration(cached);
 
     const response = await fetch(
       `${this._issuer}/.well-known/openid-configuration`,
@@ -120,23 +119,13 @@ export class OidcDiscoveryCache {
       return undefined;
 
     const maxAgeMatch = /(?:^|,)\s*max-age\s*=\s*"?(\d+)"?/i.exec(cacheControl);
-    if (!maxAgeMatch)
-      return undefined;
+    if (!maxAgeMatch) return undefined;
 
-    const ageHeader = Number.parseInt(headers.get("age") ?? "0", 10);
-    const responseDate = Date.parse(headers.get("date") ?? "");
-    const apparentAge = Number.isFinite(responseDate)
-      ? Math.max(0, (Date.now() - responseDate) / 1000)
-      : 0;
-    const age = Math.max(
-      Number.isFinite(ageHeader) ? ageHeader : 0,
-      apparentAge,
-    );
     const maxAge = Math.min(
       Number.parseInt(maxAgeMatch[1], 10),
       maximumCacheAgeSeconds,
     );
-    const remainingAge = Math.max(0, maxAge - age);
+    return maxAge > 0 ? Date.now() + maxAge * 1000 : undefined;
     return remainingAge > 0 ? Date.now() + remainingAge * 1000 : undefined;
   }
 

--- a/packages/electron/src/main/OidcDiscoveryCache.ts
+++ b/packages/electron/src/main/OidcDiscoveryCache.ts
@@ -190,9 +190,7 @@ function getExpiration(headers: Headers): number | undefined {
       ? Number.parseInt(ageHeader, 10)
       : 0;
   const remainingMaxAge = maxAge - age;
-  return remainingMaxAge > 0
-    ? Date.now() + remainingMaxAge * 1000
-    : undefined;
+  return remainingMaxAge > 0 ? Date.now() + remainingMaxAge * 1000 : undefined;
 }
 
 function isCachedExpired(expiresAt: unknown): boolean {

--- a/packages/electron/src/main/OidcDiscoveryCache.ts
+++ b/packages/electron/src/main/OidcDiscoveryCache.ts
@@ -10,6 +10,9 @@ import { safeStorage } from "electron";
 import { electronAuthLoggerCategory } from "../common/constants.js";
 const Store = require("electron-store"); // eslint-disable-line @typescript-eslint/no-require-imports, @typescript-eslint/naming-convention
 
+// NOTE: this logic is almost identical to the logic in the node-cli OidcDiscoveryCache.
+// A future refactor could extract this logic into a shared class.
+
 const cacheVersion = 1;
 const maximumCacheAgeSeconds = 24 * 60 * 60;
 
@@ -31,8 +34,8 @@ export class OidcDiscoveryCache {
   private readonly _cacheKey: string;
 
   public constructor(issuer: string, dir?: string) {
-    this._issuer = issuer;
-    this._cacheKey = encodeCacheKey(issuer);
+    this._issuer = normalizeIssuerUrl(issuer);
+    this._cacheKey = encodeCacheKey(this._issuer);
     this._store = new Store({
       name: "iTwinJs_oidcDiscoveryCache",
       encryptionKey: "iTwin",
@@ -59,7 +62,7 @@ export class OidcDiscoveryCache {
     this.validate(document);
 
     const configuration = new AuthorizationServiceConfiguration(document);
-    const expiresAt = this.getExpiration(response.headers);
+    const expiresAt = getExpiration(response.headers);
     if (expiresAt)
       await this.save({
         version: cacheVersion,
@@ -119,57 +122,31 @@ export class OidcDiscoveryCache {
     }
   }
 
-  private getExpiration(headers: Headers): number | undefined {
-    const cacheControl = headers.get("cache-control");
-    if (
-      !cacheControl ||
-      /(?:^|,)\s*(?:no-store|no-cache)\s*(?:,|$)/i.test(cacheControl)
-    )
-      return undefined;
-
-    const maxAgeMatch = /(?:^|,)\s*max-age\s*=\s*"?(\d+)"?/i.exec(cacheControl);
-    if (!maxAgeMatch) return undefined;
-
-    const maxAge = Math.min(
-      Number.parseInt(maxAgeMatch[1], 10),
-      maximumCacheAgeSeconds,
-    );
-    return maxAge > 0 ? Date.now() + maxAge * 1000 : undefined;
-  }
-
   private validate(document: DiscoveryDocument): void {
-    if (document.issuer !== this._issuer)
+    if (
+      typeof document.issuer !== "string" ||
+      normalizeIssuerUrl(document.issuer) !== this._issuer
+    )
       throw new Error(
         "OIDC discovery response issuer does not match the configured issuer",
       );
 
-    for (const [name, endpoint] of [
+    const requiredEndpoints = [
       ["authorization_endpoint", document.authorization_endpoint],
       ["token_endpoint", document.token_endpoint],
+    ] as const;
+    const optionalEndpoints = [
       ["revocation_endpoint", document.revocation_endpoint],
-    ]) {
-      if (typeof endpoint !== "string" || endpoint.length === 0)
-        throw new Error(`OIDC discovery response is missing ${name}`);
-    }
+      ["end_session_endpoint", document.end_session_endpoint],
+      ["userinfo_endpoint", document.userinfo_endpoint],
+    ] as const;
 
     const issuer = new URL(this._issuer);
     if (issuer.protocol !== "https:")
       throw new Error("OIDC issuer must use HTTPS");
 
-    for (const endpoint of [
-      document.authorization_endpoint,
-      document.token_endpoint,
-      document.revocation_endpoint,
-      document.end_session_endpoint,
-      document.userinfo_endpoint,
-    ]) {
-      if (!endpoint) continue;
-
-      if (!isValidEndpointUrl(endpoint, issuer))
-        throw new Error(
-          `OIDC endpoints must use HTTPS and Bentley endpoints must use the configured issuer origin: issuer=${issuer}, endpoint=${endpoint}`,
-        );
-    }
+    validateEndpoints(requiredEndpoints, issuer, false);
+    validateEndpoints(optionalEndpoints, issuer, true);
   }
 
   private async encrypt(value: string): Promise<Buffer> {
@@ -186,6 +163,36 @@ export class OidcDiscoveryCache {
  */
 function encodeCacheKey(value: string): string {
   return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function normalizeIssuerUrl(value: string): string {
+  return new URL(value).href.replace(/\/$/, "");
+}
+
+function getExpiration(headers: Headers): number | undefined {
+  const cacheControl = headers.get("cache-control");
+  if (
+    !cacheControl ||
+    /(?:^|,)\s*(?:no-store|no-cache)\s*(?:,|$)/i.test(cacheControl)
+  )
+    return undefined;
+
+  const maxAgeMatch = /(?:^|,)\s*max-age\s*=\s*"?(\d+)"?/i.exec(cacheControl);
+  if (!maxAgeMatch) return undefined;
+
+  const maxAge = Math.min(
+    Number.parseInt(maxAgeMatch[1], 10),
+    maximumCacheAgeSeconds,
+  );
+  const ageHeader = headers.get("age");
+  const age =
+    ageHeader && /^\d+$/.test(ageHeader.trim())
+      ? Number.parseInt(ageHeader, 10)
+      : 0;
+  const remainingMaxAge = maxAge - age;
+  return remainingMaxAge > 0
+    ? Date.now() + remainingMaxAge * 1000
+    : undefined;
 }
 
 function isCachedExpired(expiresAt: unknown): boolean {
@@ -208,5 +215,23 @@ function isValidEndpointUrl(endpoint: string, issuer: URL): boolean {
     );
   } catch {
     return false;
+  }
+}
+
+function validateEndpoints(
+  endpoints: ReadonlyArray<readonly [string, unknown]>,
+  issuer: URL,
+  optional: boolean,
+): void {
+  for (const [name, endpoint] of endpoints) {
+    if (endpoint === undefined && optional) continue;
+
+    if (typeof endpoint !== "string" || endpoint.length === 0)
+      throw new Error(`OIDC discovery response is missing ${name}`);
+
+    if (!isValidEndpointUrl(endpoint, issuer))
+      throw new Error(
+        `OIDC endpoints must use HTTPS and Bentley endpoints must use the configured issuer origin: issuer=${issuer}, endpoint=${endpoint}`,
+      );
   }
 }

--- a/packages/electron/src/main/OidcDiscoveryCache.ts
+++ b/packages/electron/src/main/OidcDiscoveryCache.ts
@@ -142,8 +142,6 @@ export class OidcDiscoveryCache {
     ] as const;
 
     const issuer = new URL(this._issuer);
-    if (issuer.protocol !== "https:")
-      throw new Error("OIDC issuer must use HTTPS");
 
     validateEndpoints(requiredEndpoints, issuer, false);
     validateEndpoints(optionalEndpoints, issuer, true);
@@ -166,7 +164,11 @@ function encodeCacheKey(value: string): string {
 }
 
 function normalizeIssuerUrl(value: string): string {
-  return new URL(value).href.replace(/\/$/, "");
+  const issuer = new URL(value);
+  if (issuer.protocol !== "https:")
+    throw new Error("OIDC issuer must use HTTPS");
+
+  return issuer.href.replace(/\/$/, "");
 }
 
 function getExpiration(headers: Headers): number | undefined {

--- a/packages/electron/src/main/OidcDiscoveryCache.ts
+++ b/packages/electron/src/main/OidcDiscoveryCache.ts
@@ -30,7 +30,7 @@ export class OidcDiscoveryCache {
 
   public constructor(issuer: string, dir?: string) {
     this._issuer = issuer;
-    this._cacheKey = encodeURIComponent(issuer);
+    this._cacheKey = encodeCacheKey(issuer);
     this._store = new Store({
       name: "iTwinJs_oidcDiscoveryCache",
       encryptionKey: "iTwin",
@@ -171,6 +171,13 @@ export class OidcDiscoveryCache {
   private async decrypt(value: Buffer): Promise<string> {
     return safeStorage.decryptString(Buffer.from(value));
   }
+}
+
+/**
+ * Encode a string to be used as a cache key, returning a value with only alphanumeric, dash and underscore characters.
+ */
+function encodeCacheKey(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
 }
 
 function isValidEndpointUrl(endpoint: string, issuer: URL): boolean {

--- a/packages/electron/src/main/OidcDiscoveryCache.ts
+++ b/packages/electron/src/main/OidcDiscoveryCache.ts
@@ -6,8 +6,7 @@
 import type { AuthorizationServiceConfigurationJson } from "@openid/appauth";
 import { AuthorizationServiceConfiguration } from "@openid/appauth";
 import { safeStorage } from "electron";
-// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-var-requires
-const Store = require("electron-store"); // eslint-disable-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const Store = require("electron-store"); // eslint-disable-line @typescript-eslint/no-require-imports, @typescript-eslint/naming-convention
 
 const cacheVersion = 1;
 const maximumCacheAgeSeconds = 24 * 60 * 60;

--- a/packages/electron/src/test/OidcDiscoveryCache.test.ts
+++ b/packages/electron/src/test/OidcDiscoveryCache.test.ts
@@ -19,6 +19,13 @@ const discoveryDocument = {
   revocation_endpoint: `${issuer}/connect/revoke`,
   end_session_endpoint: `${issuer}/connect/endsession`,
 };
+
+type TestDiscoveryDocument = Omit<
+  typeof discoveryDocument,
+  "revocation_endpoint"
+> & {
+  revocation_endpoint?: string;
+};
 /* eslint-enable @typescript-eslint/naming-convention */
 
 describe("OidcDiscoveryCache", () => {
@@ -43,12 +50,19 @@ describe("OidcDiscoveryCache", () => {
     await rm(cacheDirectory, { recursive: true, force: true });
   });
 
-  function stubDiscovery(cacheControl = "max-age=86400") {
+  function stubDiscovery(
+    cacheControl = "max-age=86400",
+    document: TestDiscoveryDocument = discoveryDocument,
+    age?: string,
+  ) {
     return sinon.stub(globalThis, "fetch").resolves({
       ok: true,
       status: 200,
-      headers: new Headers({ "cache-control": cacheControl }),
-      json: async () => discoveryDocument,
+      headers: new Headers({
+        "cache-control": cacheControl,
+        ...(age ? { age } : {}),
+      }),
+      json: async () => document,
     } as Response);
   }
 
@@ -72,6 +86,41 @@ describe("OidcDiscoveryCache", () => {
     await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
 
     sinon.assert.calledTwice(fetchStub);
+  });
+
+  it("does not persist a stale response based on its Age header", async () => {
+    const fetchStub = stubDiscovery(
+      "max-age=86400",
+      discoveryDocument,
+      "86400",
+    );
+
+    await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
+    await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
+
+    sinon.assert.calledTwice(fetchStub);
+  });
+
+  it("allows optional endpoints to be omitted", async () => {
+    const { revocation_endpoint: _, ...documentWithoutRevocation } =
+      discoveryDocument;
+    stubDiscovery("max-age=86400", documentWithoutRevocation);
+
+    const configuration = await new OidcDiscoveryCache(
+      issuer,
+      cacheDirectory,
+    ).getConfiguration();
+
+    assert.isUndefined(configuration.revocationEndpoint);
+  });
+
+  it("accepts an equivalent issuer with a trailing slash", async () => {
+    stubDiscovery("max-age=86400", {
+      ...discoveryDocument,
+      issuer: `${issuer}/`,
+    });
+
+    await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
   });
 
   it("treats an undecryptable cache entry as a miss", async () => {

--- a/packages/electron/src/test/OidcDiscoveryCache.test.ts
+++ b/packages/electron/src/test/OidcDiscoveryCache.test.ts
@@ -1,0 +1,121 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { assert } from "chai";
+import * as sinon from "sinon";
+import { OidcDiscoveryCache } from "../main/OidcDiscoveryCache.js";
+
+const issuer = "https://qa-ims.bentley.com";
+const discoveryDocument = {
+  issuer,
+  authorization_endpoint: `${issuer}/connect/authorize`,
+  token_endpoint: `${issuer}/connect/token`,
+  revocation_endpoint: `${issuer}/connect/revoke`,
+  end_session_endpoint: `${issuer}/connect/endsession`,
+};
+
+describe("OidcDiscoveryCache", () => {
+  let cacheDirectory: string;
+  let decryptStub: sinon.SinonStub;
+
+  beforeEach(async () => {
+    sinon.restore();
+    cacheDirectory = await mkdtemp(join(tmpdir(), "electron-oidc-discovery-"));
+    sinon
+      .stub(OidcDiscoveryCache.prototype, "encrypt" as any)
+      .callsFake(async (...args: unknown[]) => Buffer.from(args[0] as string));
+    decryptStub = sinon
+      .stub(OidcDiscoveryCache.prototype, "decrypt" as any)
+      .callsFake(async (...args: unknown[]) =>
+        Buffer.from(args[0] as Buffer).toString(),
+      );
+  });
+
+  afterEach(async () => {
+    sinon.restore();
+    await rm(cacheDirectory, { recursive: true, force: true });
+  });
+
+  function stubDiscovery(cacheControl = "max-age=86400") {
+    return sinon.stub(globalThis, "fetch").resolves({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "cache-control": cacheControl }),
+      json: async () => discoveryDocument,
+    } as Response);
+  }
+
+  it("reuses a fresh encrypted configuration across instances", async () => {
+    const fetchStub = stubDiscovery();
+
+    await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
+    const cached = await new OidcDiscoveryCache(
+      issuer,
+      cacheDirectory,
+    ).getConfiguration();
+
+    sinon.assert.calledOnce(fetchStub);
+    assert.equal(cached.tokenEndpoint, discoveryDocument.token_endpoint);
+  });
+
+  it("does not persist a response marked no-store", async () => {
+    const fetchStub = stubDiscovery("no-store, max-age=86400");
+
+    await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
+    await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
+
+    sinon.assert.calledTwice(fetchStub);
+  });
+
+  it("treats an undecryptable cache entry as a miss", async () => {
+    const fetchStub = stubDiscovery();
+    await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
+
+    decryptStub.rejects(new Error("tampered"));
+    await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
+
+    sinon.assert.calledTwice(fetchStub);
+  });
+
+  it("rejects a Bentley token endpoint on another origin", async () => {
+    sinon.stub(globalThis, "fetch").resolves({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "cache-control": "max-age=86400" }),
+      json: async () => ({
+        ...discoveryDocument,
+        token_endpoint: "https://example.com/connect/token",
+      }),
+    } as Response);
+
+    await assert.isRejected(
+      new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration(),
+      "configured issuer origin",
+    );
+  });
+
+  it("rejects an HTTP loopback issuer", async () => {
+    const loopbackIssuer = "http://127.0.0.1:3000";
+    sinon.stub(globalThis, "fetch").resolves({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "cache-control": "max-age=86400" }),
+      json: async () => ({
+        issuer: loopbackIssuer,
+        authorization_endpoint: `${loopbackIssuer}/authorize`,
+        token_endpoint: `${loopbackIssuer}/token`,
+        revocation_endpoint: `${loopbackIssuer}/revoke`,
+      }),
+    } as Response);
+
+    await assert.isRejected(
+      new OidcDiscoveryCache(loopbackIssuer, cacheDirectory).getConfiguration(),
+      "issuer must use HTTPS",
+    );
+  });
+});

--- a/packages/electron/src/test/OidcDiscoveryCache.test.ts
+++ b/packages/electron/src/test/OidcDiscoveryCache.test.ts
@@ -152,24 +152,10 @@ describe("OidcDiscoveryCache", () => {
     );
   });
 
-  it("rejects an HTTP loopback issuer", async () => {
+  it("rejects an HTTP loopback issuer", () => {
     const loopbackIssuer = "http://127.0.0.1:3000";
-    /* eslint-disable @typescript-eslint/naming-convention */
-    sinon.stub(globalThis, "fetch").resolves({
-      ok: true,
-      status: 200,
-      headers: new Headers({ "cache-control": "max-age=86400" }),
-      json: async () => ({
-        issuer: loopbackIssuer,
-        authorization_endpoint: `${loopbackIssuer}/authorize`,
-        token_endpoint: `${loopbackIssuer}/token`,
-        revocation_endpoint: `${loopbackIssuer}/revoke`,
-      }),
-    } as Response);
-    /* eslint-enable @typescript-eslint/naming-convention */
-
-    await assert.isRejected(
-      new OidcDiscoveryCache(loopbackIssuer, cacheDirectory).getConfiguration(),
+    assert.throws(
+      () => new OidcDiscoveryCache(loopbackIssuer, cacheDirectory),
       "issuer must use HTTPS",
     );
   });

--- a/packages/electron/src/test/OidcDiscoveryCache.test.ts
+++ b/packages/electron/src/test/OidcDiscoveryCache.test.ts
@@ -11,6 +11,7 @@ import * as sinon from "sinon";
 import { OidcDiscoveryCache } from "../main/OidcDiscoveryCache.js";
 
 const issuer = "https://qa-ims.bentley.com";
+/* eslint-disable @typescript-eslint/naming-convention */
 const discoveryDocument = {
   issuer,
   authorization_endpoint: `${issuer}/connect/authorize`,
@@ -18,6 +19,7 @@ const discoveryDocument = {
   revocation_endpoint: `${issuer}/connect/revoke`,
   end_session_endpoint: `${issuer}/connect/endsession`,
 };
+/* eslint-enable @typescript-eslint/naming-convention */
 
 describe("OidcDiscoveryCache", () => {
   let cacheDirectory: string;
@@ -83,6 +85,7 @@ describe("OidcDiscoveryCache", () => {
   });
 
   it("rejects a Bentley token endpoint on another origin", async () => {
+    /* eslint-disable @typescript-eslint/naming-convention */
     sinon.stub(globalThis, "fetch").resolves({
       ok: true,
       status: 200,
@@ -92,6 +95,7 @@ describe("OidcDiscoveryCache", () => {
         token_endpoint: "https://example.com/connect/token",
       }),
     } as Response);
+    /* eslint-enable @typescript-eslint/naming-convention */
 
     await assert.isRejected(
       new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration(),
@@ -101,6 +105,7 @@ describe("OidcDiscoveryCache", () => {
 
   it("rejects an HTTP loopback issuer", async () => {
     const loopbackIssuer = "http://127.0.0.1:3000";
+    /* eslint-disable @typescript-eslint/naming-convention */
     sinon.stub(globalThis, "fetch").resolves({
       ok: true,
       status: 200,
@@ -112,6 +117,7 @@ describe("OidcDiscoveryCache", () => {
         revocation_endpoint: `${loopbackIssuer}/revoke`,
       }),
     } as Response);
+    /* eslint-enable @typescript-eslint/naming-convention */
 
     await assert.isRejected(
       new OidcDiscoveryCache(loopbackIssuer, cacheDirectory).getConfiguration(),

--- a/packages/electron/src/test/helpers/testHelper.ts
+++ b/packages/electron/src/test/helpers/testHelper.ts
@@ -1,11 +1,12 @@
-import type { AuthorizationListener, AuthorizationServiceConfiguration, TokenRequest } from "@openid/appauth";
-import { AuthorizationNotifier, AuthorizationRequest, AuthorizationResponse, BaseTokenRequestHandler, TokenResponse } from "@openid/appauth";
+import type { AuthorizationListener, TokenRequest } from "@openid/appauth";
+import { AuthorizationNotifier, AuthorizationServiceConfiguration, AuthorizationRequest, AuthorizationResponse, BaseTokenRequestHandler, TokenResponse } from "@openid/appauth";
 import type { ElectronMainAuthorizationConfiguration } from "../../ElectronMain.js";
 import { ElectronMainAuthorization } from "../../main/Client.js";
 import * as sinon from "sinon";
 import { LoopbackWebServer } from "../../main/LoopbackWebServer.js";
 import { ElectronMainAuthorizationRequestHandler } from "../../main/ElectronMainAuthorizationRequestHandler.js";
 import { RefreshTokenStore } from "../../main/TokenStore.js";
+import { OidcDiscoveryCache } from "../../main/OidcDiscoveryCache.js";
 
 interface ClientConfig {
   clientId?: string;
@@ -53,34 +54,66 @@ export function getMockTokenResponse({ accessToken, refreshToken, issuedAt, expi
  * Setup a mock auth server and listen for refresh token calls
  * @returns a spy which can be used to make assertions on the refresh token call
  */
-export async function setupMockAuthServer(mockTokenResponse: TokenResponse, setupMockAuthServerOptions: SetupMockAuthServerOptions = {}): Promise<sinon.SinonSpy<any[], any>> {
-  sinon.stub(LoopbackWebServer, "start").resolves();
-  sinon.stub(ElectronMainAuthorizationRequestHandler.prototype, "performAuthorizationRequest").callsFake(async () => {
-    await new Promise((resolve) => setImmediate(resolve, () => { }));
-  });
-  const spy = sinon.fake();
-  sinon.stub(ElectronMainAuthorization.prototype, "refreshToken").callsFake(spy);
-  sinon.stub(BaseTokenRequestHandler.prototype, "performTokenRequest").callsFake(async (_configuration: AuthorizationServiceConfiguration, _request: TokenRequest) => {
-    if (setupMockAuthServerOptions.performTokenRequestCb) {
-      await setupMockAuthServerOptions.performTokenRequestCb();
-    }
-    return mockTokenResponse;
-  });
-
-  sinon.stub(AuthorizationNotifier.prototype, "setAuthorizationListener").callsFake((listener: AuthorizationListener) => {
-    const authRequest = new AuthorizationRequest({
+export async function setupMockAuthServer(
+  mockTokenResponse: TokenResponse,
+  setupMockAuthServerOptions: SetupMockAuthServerOptions = {},
+): Promise<sinon.SinonSpy<any[], any>> {
+  sinon.stub(OidcDiscoveryCache.prototype, "getConfiguration").resolves(
+    new AuthorizationServiceConfiguration({
       /* eslint-disable @typescript-eslint/naming-convention */
-      response_type: "testResponseType",
-      client_id: "testClient",
-      redirect_uri: "testRedirect",
-      scope: "testScope",
-      internal: { code_verifier: "testCodeVerifier" },
-      state: "testState",
+      authorization_endpoint: "https://ims.bentley.com/connect/authorize",
+      token_endpoint: "https://ims.bentley.com/connect/token",
+      revocation_endpoint: "https://ims.bentley.com/connect/revoke",
+      end_session_endpoint: "https://ims.bentley.com/connect/endsession",
+      /* eslint-enable @typescript-eslint/naming-convention */
+    }),
+  );
+  sinon.stub(LoopbackWebServer, "start").resolves();
+  sinon
+    .stub(
+      ElectronMainAuthorizationRequestHandler.prototype,
+      "performAuthorizationRequest",
+    )
+    .callsFake(async () => {
+      await new Promise((resolve) => setImmediate(resolve, () => {}));
     });
+  const spy = sinon.fake();
+  sinon
+    .stub(ElectronMainAuthorization.prototype, "refreshToken")
+    .callsFake(spy);
+  sinon
+    .stub(BaseTokenRequestHandler.prototype, "performTokenRequest")
+    .callsFake(
+      async (
+        _configuration: AuthorizationServiceConfiguration,
+        _request: TokenRequest,
+      ) => {
+        if (setupMockAuthServerOptions.performTokenRequestCb) {
+          await setupMockAuthServerOptions.performTokenRequestCb();
+        }
+        return mockTokenResponse;
+      },
+    );
 
-    const authResponse = new AuthorizationResponse({ code: "testCode", state: "testState" });
-    listener(authRequest, authResponse, null);
-  });
+  sinon
+    .stub(AuthorizationNotifier.prototype, "setAuthorizationListener")
+    .callsFake((listener: AuthorizationListener) => {
+      const authRequest = new AuthorizationRequest({
+        /* eslint-disable @typescript-eslint/naming-convention */
+        response_type: "testResponseType",
+        client_id: "testClient",
+        redirect_uri: "testRedirect",
+        scope: "testScope",
+        internal: { code_verifier: "testCodeVerifier" },
+        state: "testState",
+      });
+
+      const authResponse = new AuthorizationResponse({
+        code: "testCode",
+        state: "testState",
+      });
+      listener(authRequest, authResponse, null);
+    });
 
   return spy;
 }

--- a/packages/electron/src/test/helpers/testHelper.ts
+++ b/packages/electron/src/test/helpers/testHelper.ts
@@ -1,5 +1,5 @@
 import type { AuthorizationListener, TokenRequest } from "@openid/appauth";
-import { AuthorizationNotifier, AuthorizationServiceConfiguration, AuthorizationRequest, AuthorizationResponse, BaseTokenRequestHandler, TokenResponse } from "@openid/appauth";
+import { AuthorizationNotifier, AuthorizationRequest, AuthorizationResponse, AuthorizationServiceConfiguration, BaseTokenRequestHandler, TokenResponse } from "@openid/appauth";
 import type { ElectronMainAuthorizationConfiguration } from "../../ElectronMain.js";
 import { ElectronMainAuthorization } from "../../main/Client.js";
 import * as sinon from "sinon";

--- a/packages/node-cli/README.md
+++ b/packages/node-cli/README.md
@@ -70,3 +70,11 @@ Note that your registered application's redirectUri must start with `http://loca
 See the [AccessToken](https://www.itwinjs.org/learning/common/accesstoken/) article in the iTwin.js documentation for background on authorization in iTwin.js.
 
 The OAuth2.0 workflow used in this package is Authorization Code + PKCE, for more information about the flow please visit the [Authorization Overview Page](https://developer.bentley.com/apis/overview/authorization/#authorizesinglepageapplicationsspaanddesktopmobileapplicationsnative).
+
+## Manually verify authorization
+
+Run the interactive authorization flow against a registered Native application:
+
+```sh
+IMJS_OIDC_CLIENT_ID=native-... IMJS_OIDC_ISSUER_URL=https://qa-ims.bentley.com pnpm --filter @itwin/node-cli-authorization verify:flow
+```

--- a/packages/node-cli/package.json
+++ b/packages/node-cli/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "npm run lint -- --fix",
     "test": "mocha \"./lib/cjs/test/**/*.test.js\"",
     "cover": "nyc npm test",
+    "verify:flow": "pnpm build && node scripts/verify-flow.cjs",
     "pack": "npm pack",
     "rebuild": "npm run clean && npm run build"
   },

--- a/packages/node-cli/scripts/verify-flow.cjs
+++ b/packages/node-cli/scripts/verify-flow.cjs
@@ -1,0 +1,55 @@
+// Run from the repository root:
+// pnpm --filter @itwin/node-cli-authorization build
+// IMJS_OIDC_CLIENT_ID=native-... IMJS_OIDC_ISSUER_URL=https://qa-ims.bentley.com node packages/node-cli/scripts/verify-flow.cjs
+
+const os = require("node:os");
+const path = require("node:path");
+const { Logger, LogLevel } = require("@itwin/core-bentley");
+const {
+  NodeCliAuthorizationClient,
+  NODE_CLI_AUTH_LOGGER_CATEGORY,
+} = require("../lib/cjs");
+
+Logger.initializeToConsole();
+Logger.setLevel(NODE_CLI_AUTH_LOGGER_CATEGORY, LogLevel.Trace);
+
+const clientId = process.env.IMJS_OIDC_CLIENT_ID;
+if (!clientId) {
+  console.error(
+    "Set IMJS_OIDC_CLIENT_ID to your Native application client ID.",
+  );
+  process.exitCode = 1;
+  return;
+}
+
+const issuerUrl = process.env.IMJS_OIDC_ISSUER_URL ?? "https://ims.bentley.com";
+const redirectUri =
+  process.env.IMJS_OIDC_REDIRECT_URI ?? "http://localhost:3000/signin-callback";
+const scope = process.env.IMJS_OIDC_SCOPES ?? "itwin-platform";
+const tokenStorePath =
+  process.env.IMJS_AUTH_CACHE_DIR ??
+  path.join(os.tmpdir(), "itwin-auth-clients", "node-cli-flow");
+
+async function main() {
+  console.log(`Cache: ${tokenStorePath}`);
+
+  const client = new NodeCliAuthorizationClient({
+    clientId,
+    issuerUrl,
+    redirectUri,
+    scope,
+    tokenStorePath,
+  });
+
+  const startedAt = Date.now();
+  await client.signIn();
+  const accessToken = await client.getAccessToken();
+
+  if (!accessToken.startsWith("Bearer "))
+    throw new Error("Authorization completed without a bearer token");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/node-cli/src/Client.ts
+++ b/packages/node-cli/src/Client.ts
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 // Code based on the blog article @ https://authguidance.com
 
 /** @packageDocumentation
@@ -12,12 +12,21 @@ import { readFileSync } from "fs";
 import * as path from "path";
 import * as Http from "http";
 import { assert, BeEvent, BentleyError, Logger } from "@itwin/core-bentley";
+import type { AuthorizationServiceConfiguration } from "@openid/appauth";
 import {
-  AuthorizationError, AuthorizationNotifier, AuthorizationRequest, AuthorizationRequestHandler, AuthorizationResponse,
-  AuthorizationServiceConfiguration, BaseTokenRequestHandler, BasicQueryStringUtils, GRANT_TYPE_AUTHORIZATION_CODE, GRANT_TYPE_REFRESH_TOKEN,
+  AuthorizationError,
+  AuthorizationNotifier,
+  AuthorizationRequest,
+  AuthorizationRequestHandler,
+  AuthorizationResponse,
+  BaseTokenRequestHandler,
+  BasicQueryStringUtils,
+  GRANT_TYPE_AUTHORIZATION_CODE,
+  GRANT_TYPE_REFRESH_TOKEN,
   TokenRequest,
 } from "@openid/appauth";
 import { NodeCrypto, NodeRequestor } from "@openid/appauth/built/node_support";
+import { OidcDiscoveryCache } from "./OidcDiscoveryCache";
 import { TokenStore } from "./TokenStore";
 import type { TokenEncryption } from "./TokenEncryption";
 
@@ -25,8 +34,13 @@ import type { AccessToken } from "@itwin/core-bentley";
 import type { AuthorizationClient } from "@itwin/core-common";
 
 import type {
-  AuthorizationErrorJson, AuthorizationRequestJson, AuthorizationRequestResponse, AuthorizationResponseJson, TokenRequestHandler,
-  TokenRequestJson, TokenResponse,
+  AuthorizationErrorJson,
+  AuthorizationRequestJson,
+  AuthorizationRequestResponse,
+  AuthorizationResponseJson,
+  TokenRequestHandler,
+  TokenRequestJson,
+  TokenResponse,
 } from "@openid/appauth";
 
 /**
@@ -104,6 +118,7 @@ export class NodeCliAuthorizationClient implements AuthorizationClient {
   private _bakedConfig: BakedAuthorizationConfiguration;
 
   private _tokenStore: TokenStore;
+  private _oidcDiscoveryCache: OidcDiscoveryCache;
   private _configuration?: AuthorizationServiceConfiguration;
   private _tokenResponse?: TokenResponse;
   private _expiresAt?: Date;
@@ -113,6 +128,10 @@ export class NodeCliAuthorizationClient implements AuthorizationClient {
   public constructor(config: NodeCliAuthorizationConfiguration) {
     this._bakedConfig = new BakedAuthorizationConfiguration(config);
     this._tokenStore = new TokenStore({ ...this._bakedConfig }, config.tokenStorePath, config.tokenEncryption);
+    this._oidcDiscoveryCache = new OidcDiscoveryCache(
+      this._bakedConfig.issuerUrl,
+      config.tokenStorePath,
+    );
   }
 
   /**
@@ -179,7 +198,7 @@ export class NodeCliAuthorizationClient implements AuthorizationClient {
   private async initialize() {
     // Would ideally set up in constructor, but async...
     if (!this._configuration)
-      this._configuration = await AuthorizationServiceConfiguration.fetchFromIssuer(this._bakedConfig.issuerUrl, new NodeRequestor());
+      this._configuration = await this._oidcDiscoveryCache.getConfiguration();
 
     await this._tokenStore.initialize();
   }

--- a/packages/node-cli/src/Client.ts
+++ b/packages/node-cli/src/Client.ts
@@ -42,12 +42,13 @@ import type {
   TokenRequestJson,
   TokenResponse,
 } from "@openid/appauth";
+import { NODE_CLI_AUTH_LOGGER_CATEGORY } from "./Constants";
 
 /**
  * Logger category used in this package
  * @public
  */
-export const NODE_CLI_AUTH_LOGGER_CATEGORY = "node-cli-auth";
+export { NODE_CLI_AUTH_LOGGER_CATEGORY } from "./Constants";
 
 /**
  * Client configuration to generate OIDC/OAuth tokens for command-line applications

--- a/packages/node-cli/src/Client.ts
+++ b/packages/node-cli/src/Client.ts
@@ -48,7 +48,7 @@ import { NODE_CLI_AUTH_LOGGER_CATEGORY } from "./Constants";
  * Logger category used in this package
  * @public
  */
-export { NODE_CLI_AUTH_LOGGER_CATEGORY } from "./Constants";
+export { NODE_CLI_AUTH_LOGGER_CATEGORY };
 
 /**
  * Client configuration to generate OIDC/OAuth tokens for command-line applications

--- a/packages/node-cli/src/Constants.ts
+++ b/packages/node-cli/src/Constants.ts
@@ -3,10 +3,5 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-/**
- * Refresh token 10 minutes before real expiration time (by default)
- * @internal
- */
-export const defaultExpiryBufferInSeconds = 600;
-
-export const electronAuthLoggerCategory = "electron-auth";
+/** Logger category used in this package. */
+export const NODE_CLI_AUTH_LOGGER_CATEGORY = "node-cli-auth";

--- a/packages/node-cli/src/Constants.ts
+++ b/packages/node-cli/src/Constants.ts
@@ -3,5 +3,9 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+/** @packageDocumentation
+ * @module Authorization
+ */
+
 /** Logger category used in this package. */
 export const NODE_CLI_AUTH_LOGGER_CATEGORY = "node-cli-auth";

--- a/packages/node-cli/src/OidcDiscoveryCache.ts
+++ b/packages/node-cli/src/OidcDiscoveryCache.ts
@@ -3,6 +3,10 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+/** @packageDocumentation
+ * @module Authorization
+ */
+
 import { Logger } from "@itwin/core-bentley";
 import type { AuthorizationServiceConfigurationJson } from "@openid/appauth";
 import { AuthorizationServiceConfiguration } from "@openid/appauth";

--- a/packages/node-cli/src/OidcDiscoveryCache.ts
+++ b/packages/node-cli/src/OidcDiscoveryCache.ts
@@ -3,10 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import { Logger } from "@itwin/core-bentley";
 import type { AuthorizationServiceConfigurationJson } from "@openid/appauth";
 import { AuthorizationServiceConfiguration } from "@openid/appauth";
 import * as path from "node:path";
 import * as NodePersist from "node-persist";
+import { NODE_CLI_AUTH_LOGGER_CATEGORY } from "./Constants";
 
 const cacheVersion = 1;
 const maximumCacheAgeSeconds = 24 * 60 * 60;
@@ -83,15 +85,26 @@ export class OidcDiscoveryCache {
         | undefined;
       if (!cached) return undefined;
 
-      if (
-        cached.version !== cacheVersion ||
-        isCachedExpired(cached.expiresAt)
-      ) {
+      if (cached.version !== cacheVersion) {
+        await this._store.removeItem(this._cacheKey);
+        return undefined;
+      }
+      if (isCachedExpired(cached.expiresAt)) {
+        Logger.logTrace(
+          NODE_CLI_AUTH_LOGGER_CATEGORY,
+          "Cached OIDC configuration expired",
+          () => ({ issuer: this._issuer, expiresAt: cached.expiresAt }),
+        );
         await this._store.removeItem(this._cacheKey);
         return undefined;
       }
 
       this.validate({ issuer: cached.issuer, ...cached.configuration });
+      Logger.logTrace(
+        NODE_CLI_AUTH_LOGGER_CATEGORY,
+        "Using cached OIDC configuration",
+        () => ({ issuer: this._issuer, expiresAt: cached.expiresAt }),
+      );
       return cached.configuration;
     } catch {
       try {

--- a/packages/node-cli/src/OidcDiscoveryCache.ts
+++ b/packages/node-cli/src/OidcDiscoveryCache.ts
@@ -10,6 +10,9 @@ import * as path from "node:path";
 import * as NodePersist from "node-persist";
 import { NODE_CLI_AUTH_LOGGER_CATEGORY } from "./Constants";
 
+// NOTE: this logic is almost identical to the logic in the Electron OidcDiscoveryCache.
+// A future refactor could extract this logic into a shared class.
+
 const cacheVersion = 1;
 const maximumCacheAgeSeconds = 24 * 60 * 60;
 
@@ -32,8 +35,8 @@ export class OidcDiscoveryCache {
   private _initialization?: Promise<unknown>;
 
   public constructor(issuer: string, dir?: string) {
-    this._issuer = issuer;
-    this._cacheKey = `oidcDiscovery_${encodeCacheKey(issuer)}`;
+    this._issuer = normalizeIssuerUrl(issuer);
+    this._cacheKey = `oidcDiscovery_${encodeCacheKey(this._issuer)}`;
     const cacheDirectory = dir ?? path.join(process.cwd(), ".configStore");
     this._store = NodePersist.create({ dir: cacheDirectory });
   }
@@ -57,7 +60,7 @@ export class OidcDiscoveryCache {
     this.validate(document);
 
     const configuration = new AuthorizationServiceConfiguration(document);
-    const expiresAt = this.getExpiration(response.headers);
+    const expiresAt = getExpiration(response.headers);
     if (expiresAt) {
       await this.save({
         version: cacheVersion,
@@ -125,62 +128,66 @@ export class OidcDiscoveryCache {
     }
   }
 
-  private getExpiration(headers: Headers): number | undefined {
-    const cacheControl = headers.get("cache-control");
-    if (
-      !cacheControl ||
-      /(?:^|,)\s*(?:no-store|no-cache)\s*(?:,|$)/i.test(cacheControl)
-    )
-      return undefined;
-
-    const maxAgeMatch = /(?:^|,)\s*max-age\s*=\s*"?(\d+)"?/i.exec(cacheControl);
-    if (!maxAgeMatch) return undefined;
-
-    const maxAge = Math.min(
-      Number.parseInt(maxAgeMatch[1], 10),
-      maximumCacheAgeSeconds,
-    );
-    return maxAge > 0 ? Date.now() + maxAge * 1000 : undefined;
-  }
-
   private validate(document: DiscoveryDocument): void {
-    if (document.issuer !== this._issuer)
+    if (
+      typeof document.issuer !== "string" ||
+      normalizeIssuerUrl(document.issuer) !== this._issuer
+    )
       throw new Error(
         "OIDC discovery response issuer does not match the configured issuer",
       );
 
-    for (const [name, endpoint] of [
+    const requiredEndpoints = [
       ["authorization_endpoint", document.authorization_endpoint],
       ["token_endpoint", document.token_endpoint],
+    ] as const;
+    const optionalEndpoints = [
       ["revocation_endpoint", document.revocation_endpoint],
-    ]) {
-      if (typeof endpoint !== "string" || endpoint.length === 0)
-        throw new Error(`OIDC discovery response is missing ${name}`);
-    }
+      ["end_session_endpoint", document.end_session_endpoint],
+      ["userinfo_endpoint", document.userinfo_endpoint],
+    ] as const;
 
     const issuer = new URL(this._issuer);
     if (issuer.protocol !== "https:")
       throw new Error("OIDC issuer must use HTTPS");
 
-    for (const endpoint of [
-      document.authorization_endpoint,
-      document.token_endpoint,
-      document.revocation_endpoint,
-      document.end_session_endpoint,
-      document.userinfo_endpoint,
-    ]) {
-      if (!endpoint) continue;
-
-      if (!isValidEndpointUrl(endpoint, issuer))
-        throw new Error(
-          `OIDC endpoints must use HTTPS and Bentley endpoints must use the configured issuer origin: issuer=${issuer}, endpoint=${endpoint}`,
-        );
-    }
+    validateEndpoints(requiredEndpoints, issuer, false);
+    validateEndpoints(optionalEndpoints, issuer, true);
   }
 }
 
 function encodeCacheKey(value: string): string {
   return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function normalizeIssuerUrl(value: string): string {
+  return new URL(value).href.replace(/\/$/, "");
+}
+
+function getExpiration(headers: Headers): number | undefined {
+  const cacheControl = headers.get("cache-control");
+  if (
+    !cacheControl ||
+    /(?:^|,)\s*(?:no-store|no-cache)\s*(?:,|$)/i.test(cacheControl)
+  )
+    return undefined;
+
+  const maxAgeMatch = /(?:^|,)\s*max-age\s*=\s*"?(\d+)"?/i.exec(cacheControl);
+  if (!maxAgeMatch) return undefined;
+
+  const maxAge = Math.min(
+    Number.parseInt(maxAgeMatch[1], 10),
+    maximumCacheAgeSeconds,
+  );
+  const ageHeader = headers.get("age");
+  const age =
+    ageHeader && /^\d+$/.test(ageHeader.trim())
+      ? Number.parseInt(ageHeader, 10)
+      : 0;
+  const remainingMaxAge = maxAge - age;
+  return remainingMaxAge > 0
+    ? Date.now() + remainingMaxAge * 1000
+    : undefined;
 }
 
 function isCachedExpired(expiresAt: unknown): boolean {
@@ -203,5 +210,23 @@ function isValidEndpointUrl(endpoint: string, issuer: URL): boolean {
     );
   } catch {
     return false;
+  }
+}
+
+function validateEndpoints(
+  endpoints: ReadonlyArray<readonly [string, unknown]>,
+  issuer: URL,
+  optional: boolean,
+): void {
+  for (const [name, endpoint] of endpoints) {
+    if (endpoint === undefined && optional) continue;
+
+    if (typeof endpoint !== "string" || endpoint.length === 0)
+      throw new Error(`OIDC discovery response is missing ${name}`);
+
+    if (!isValidEndpointUrl(endpoint, issuer))
+      throw new Error(
+        `OIDC endpoints must use HTTPS and Bentley endpoints must use the configured issuer origin: issuer=${issuer}, endpoint=${endpoint}`,
+      );
   }
 }

--- a/packages/node-cli/src/OidcDiscoveryCache.ts
+++ b/packages/node-cli/src/OidcDiscoveryCache.ts
@@ -185,9 +185,7 @@ function getExpiration(headers: Headers): number | undefined {
       ? Number.parseInt(ageHeader, 10)
       : 0;
   const remainingMaxAge = maxAge - age;
-  return remainingMaxAge > 0
-    ? Date.now() + remainingMaxAge * 1000
-    : undefined;
+  return remainingMaxAge > 0 ? Date.now() + remainingMaxAge * 1000 : undefined;
 }
 
 function isCachedExpired(expiresAt: unknown): boolean {

--- a/packages/node-cli/src/OidcDiscoveryCache.ts
+++ b/packages/node-cli/src/OidcDiscoveryCache.ts
@@ -148,8 +148,6 @@ export class OidcDiscoveryCache {
     ] as const;
 
     const issuer = new URL(this._issuer);
-    if (issuer.protocol !== "https:")
-      throw new Error("OIDC issuer must use HTTPS");
 
     validateEndpoints(requiredEndpoints, issuer, false);
     validateEndpoints(optionalEndpoints, issuer, true);
@@ -161,7 +159,11 @@ function encodeCacheKey(value: string): string {
 }
 
 function normalizeIssuerUrl(value: string): string {
-  return new URL(value).href.replace(/\/$/, "");
+  const issuer = new URL(value);
+  if (issuer.protocol !== "https:")
+    throw new Error("OIDC issuer must use HTTPS");
+
+  return issuer.href.replace(/\/$/, "");
 }
 
 function getExpiration(headers: Headers): number | undefined {

--- a/packages/node-cli/src/OidcDiscoveryCache.ts
+++ b/packages/node-cli/src/OidcDiscoveryCache.ts
@@ -5,8 +5,8 @@
 
 import type { AuthorizationServiceConfigurationJson } from "@openid/appauth";
 import { AuthorizationServiceConfiguration } from "@openid/appauth";
-import { safeStorage } from "electron";
-const Store = require("electron-store"); // eslint-disable-line @typescript-eslint/no-require-imports, @typescript-eslint/naming-convention
+import * as path from "node:path";
+import * as NodePersist from "node-persist";
 
 const cacheVersion = 1;
 const maximumCacheAgeSeconds = 24 * 60 * 60;
@@ -25,17 +25,15 @@ interface DiscoveryDocument extends AuthorizationServiceConfigurationJson {
 /** Persistently caches validated OIDC discovery metadata. */
 export class OidcDiscoveryCache {
   private readonly _issuer: string;
-  private readonly _store: typeof Store;
+  private readonly _store: NodePersist.LocalStorage;
   private readonly _cacheKey: string;
+  private _initialization?: Promise<unknown>;
 
   public constructor(issuer: string, dir?: string) {
     this._issuer = issuer;
-    this._cacheKey = encodeCacheKey(issuer);
-    this._store = new Store({
-      name: "iTwinJs_oidcDiscoveryCache",
-      encryptionKey: "iTwin",
-      cwd: dir ?? null,
-    });
+    this._cacheKey = `oidcDiscovery_${encodeCacheKey(issuer)}`;
+    const cacheDirectory = dir ?? path.join(process.cwd(), ".configStore");
+    this._store = NodePersist.create({ dir: cacheDirectory });
   }
 
   public async getConfiguration(): Promise<AuthorizationServiceConfiguration> {
@@ -58,51 +56,59 @@ export class OidcDiscoveryCache {
 
     const configuration = new AuthorizationServiceConfiguration(document);
     const expiresAt = this.getExpiration(response.headers);
-    if (expiresAt)
+    if (expiresAt) {
       await this.save({
         version: cacheVersion,
         issuer: this._issuer,
         expiresAt,
         configuration: configuration.toJson(),
       });
+    }
 
     return configuration;
+  }
+
+  private async initialize(): Promise<void> {
+    this._initialization ??= this._store.init();
+    await this._initialization;
   }
 
   private async load(): Promise<
     AuthorizationServiceConfigurationJson | undefined
   > {
-    if (!this._store.has(this._cacheKey)) return undefined;
-
     try {
-      const encrypted = this._store.get(this._cacheKey) as Buffer;
-      const cached = JSON.parse(
-        await this.decrypt(encrypted),
-      ) as CachedDiscoveryConfiguration;
+      await this.initialize();
+      const cached = (await this._store.getItem(this._cacheKey)) as
+        | CachedDiscoveryConfiguration
+        | undefined;
+      if (!cached) return undefined;
+
       if (
         cached.version !== cacheVersion ||
         isCachedExpired(cached.expiresAt)
       ) {
-        this._store.delete(this._cacheKey);
+        await this._store.removeItem(this._cacheKey);
         return undefined;
       }
 
       this.validate({ issuer: cached.issuer, ...cached.configuration });
       return cached.configuration;
     } catch {
-      this._store.delete(this._cacheKey);
+      try {
+        await this._store.removeItem(this._cacheKey);
+      } catch {
+        // Discovery caching is an optimization; we continue on failure.
+      }
       return undefined;
     }
   }
 
   private async save(cached: CachedDiscoveryConfiguration): Promise<void> {
     try {
-      this._store.set(
-        this._cacheKey,
-        await this.encrypt(JSON.stringify(cached)),
-      );
+      await this.initialize();
+      await this._store.setItem(this._cacheKey, cached);
     } catch {
-      // Discovery caching is an optimization; failure to persist must not prevent authorization.
+      // Discovery caching is an optimization; we continue on failure.
     }
   }
 
@@ -158,19 +164,8 @@ export class OidcDiscoveryCache {
         );
     }
   }
-
-  private async encrypt(value: string): Promise<Buffer> {
-    return safeStorage.encryptString(value);
-  }
-
-  private async decrypt(value: Buffer): Promise<string> {
-    return safeStorage.decryptString(Buffer.from(value));
-  }
 }
 
-/**
- * Encode a string to be used as a cache key, returning a value with only alphanumeric, dash and underscore characters.
- */
 function encodeCacheKey(value: string): string {
   return Buffer.from(value, "utf8").toString("base64url");
 }

--- a/packages/node-cli/src/TokenStore.ts
+++ b/packages/node-cli/src/TokenStore.ts
@@ -10,7 +10,7 @@ import { createCipheriv, createDecipheriv, createSecretKey, randomBytes } from "
 import { chmodSync, closeSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync, unlinkSync, writeSync } from "node:fs";
 import * as path from "node:path";
 import * as NodePersist from "node-persist";
-import { NODE_CLI_AUTH_LOGGER_CATEGORY } from "./Client";
+import { NODE_CLI_AUTH_LOGGER_CATEGORY } from "./Constants";
 import type { TokenEncryption } from "./TokenEncryption";
 
 type CacheEntry = TokenResponseJson & { scopesForCacheValidation?: string };

--- a/packages/node-cli/src/test/OidcDiscoveryCache.test.ts
+++ b/packages/node-cli/src/test/OidcDiscoveryCache.test.ts
@@ -20,6 +20,13 @@ const discoveryDocument = {
   revocation_endpoint: `${issuer}/connect/revoke`,
   end_session_endpoint: `${issuer}/connect/endsession`,
 };
+
+type TestDiscoveryDocument = Omit<
+  typeof discoveryDocument,
+  "revocation_endpoint"
+> & {
+  revocation_endpoint?: string;
+};
 /* eslint-enable @typescript-eslint/naming-convention */
 
 describe("OidcDiscoveryCache", () => {
@@ -35,12 +42,19 @@ describe("OidcDiscoveryCache", () => {
     await rm(cacheDirectory, { recursive: true, force: true });
   });
 
-  function stubDiscovery(cacheControl = "max-age=86400") {
+  function stubDiscovery(
+    cacheControl = "max-age=86400",
+    document: TestDiscoveryDocument = discoveryDocument,
+    age?: string,
+  ) {
     return sinon.stub(globalThis, "fetch").resolves({
       ok: true,
       status: 200,
-      headers: new Headers({ "cache-control": cacheControl }),
-      json: async () => discoveryDocument,
+      headers: new Headers({
+        "cache-control": cacheControl,
+        ...(age ? { age } : {}),
+      }),
+      json: async () => document,
     } as Response);
   }
 
@@ -64,6 +78,41 @@ describe("OidcDiscoveryCache", () => {
     await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
 
     sinon.assert.calledTwice(fetchStub);
+  });
+
+  it("does not persist a stale response based on its Age header", async () => {
+    const fetchStub = stubDiscovery(
+      "max-age=86400",
+      discoveryDocument,
+      "86400",
+    );
+
+    await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
+    await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
+
+    sinon.assert.calledTwice(fetchStub);
+  });
+
+  it("allows optional endpoints to be omitted", async () => {
+    const { revocation_endpoint: _, ...documentWithoutRevocation } =
+      discoveryDocument;
+    stubDiscovery("max-age=86400", documentWithoutRevocation);
+
+    const configuration = await new OidcDiscoveryCache(
+      issuer,
+      cacheDirectory,
+    ).getConfiguration();
+
+    assert.isUndefined(configuration.revocationEndpoint);
+  });
+
+  it("accepts an equivalent issuer with a trailing slash", async () => {
+    stubDiscovery("max-age=86400", {
+      ...discoveryDocument,
+      issuer: `${issuer}/`,
+    });
+
+    await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
   });
 
   it("treats malformed persisted metadata as a miss", async () => {

--- a/packages/node-cli/src/test/OidcDiscoveryCache.test.ts
+++ b/packages/node-cli/src/test/OidcDiscoveryCache.test.ts
@@ -153,24 +153,10 @@ describe("OidcDiscoveryCache", () => {
     );
   });
 
-  it("rejects an HTTP loopback issuer", async () => {
+  it("rejects an HTTP loopback issuer", () => {
     const loopbackIssuer = "http://127.0.0.1:3000";
-    /* eslint-disable @typescript-eslint/naming-convention */
-    sinon.stub(globalThis, "fetch").resolves({
-      ok: true,
-      status: 200,
-      headers: new Headers({ "cache-control": "max-age=86400" }),
-      json: async () => ({
-        issuer: loopbackIssuer,
-        authorization_endpoint: `${loopbackIssuer}/authorize`,
-        token_endpoint: `${loopbackIssuer}/token`,
-        revocation_endpoint: `${loopbackIssuer}/revoke`,
-      }),
-    } as Response);
-    /* eslint-enable @typescript-eslint/naming-convention */
-
-    await assert.isRejected(
-      new OidcDiscoveryCache(loopbackIssuer, cacheDirectory).getConfiguration(),
+    assert.throws(
+      () => new OidcDiscoveryCache(loopbackIssuer, cacheDirectory),
       "issuer must use HTTPS",
     );
   });

--- a/packages/node-cli/src/test/OidcDiscoveryCache.test.ts
+++ b/packages/node-cli/src/test/OidcDiscoveryCache.test.ts
@@ -1,0 +1,128 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { assert } from "chai";
+import * as NodePersist from "node-persist";
+import * as sinon from "sinon";
+import { OidcDiscoveryCache } from "../OidcDiscoveryCache";
+
+const issuer = "https://qa-ims.bentley.com";
+/* eslint-disable @typescript-eslint/naming-convention */
+const discoveryDocument = {
+  issuer,
+  authorization_endpoint: `${issuer}/connect/authorize`,
+  token_endpoint: `${issuer}/connect/token`,
+  revocation_endpoint: `${issuer}/connect/revoke`,
+  end_session_endpoint: `${issuer}/connect/endsession`,
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+describe("OidcDiscoveryCache", () => {
+  let cacheDirectory: string;
+
+  beforeEach(async () => {
+    sinon.restore();
+    cacheDirectory = await mkdtemp(join(tmpdir(), "node-cli-oidc-discovery-"));
+  });
+
+  afterEach(async () => {
+    sinon.restore();
+    await rm(cacheDirectory, { recursive: true, force: true });
+  });
+
+  function stubDiscovery(cacheControl = "max-age=86400") {
+    return sinon.stub(globalThis, "fetch").resolves({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "cache-control": cacheControl }),
+      json: async () => discoveryDocument,
+    } as Response);
+  }
+
+  it("reuses a fresh configuration across instances", async () => {
+    const fetchStub = stubDiscovery();
+
+    await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
+    const cached = await new OidcDiscoveryCache(
+      issuer,
+      cacheDirectory,
+    ).getConfiguration();
+
+    sinon.assert.calledOnce(fetchStub);
+    assert.equal(cached.tokenEndpoint, discoveryDocument.token_endpoint);
+  });
+
+  it("does not persist a response marked no-store", async () => {
+    const fetchStub = stubDiscovery("no-store, max-age=86400");
+
+    await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
+    await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
+
+    sinon.assert.calledTwice(fetchStub);
+  });
+
+  it("treats malformed persisted metadata as a miss", async () => {
+    const fetchStub = stubDiscovery();
+    const store = NodePersist.create({ dir: cacheDirectory });
+    await store.init();
+    await store.setItem(
+      `oidcDiscovery_${Buffer.from(issuer, "utf8").toString("base64url")}`,
+      {
+        version: 1,
+        issuer,
+        expiresAt: "invalid",
+        configuration: discoveryDocument,
+      },
+    );
+
+    await new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration();
+
+    sinon.assert.calledOnce(fetchStub);
+  });
+
+  it("rejects a Bentley token endpoint on another origin", async () => {
+    /* eslint-disable @typescript-eslint/naming-convention */
+    sinon.stub(globalThis, "fetch").resolves({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "cache-control": "max-age=86400" }),
+      json: async () => ({
+        ...discoveryDocument,
+        token_endpoint: "https://example.com/connect/token",
+      }),
+    } as Response);
+    /* eslint-enable @typescript-eslint/naming-convention */
+
+    await assert.isRejected(
+      new OidcDiscoveryCache(issuer, cacheDirectory).getConfiguration(),
+      "configured issuer origin",
+    );
+  });
+
+  it("rejects an HTTP loopback issuer", async () => {
+    const loopbackIssuer = "http://127.0.0.1:3000";
+    /* eslint-disable @typescript-eslint/naming-convention */
+    sinon.stub(globalThis, "fetch").resolves({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "cache-control": "max-age=86400" }),
+      json: async () => ({
+        issuer: loopbackIssuer,
+        authorization_endpoint: `${loopbackIssuer}/authorize`,
+        token_endpoint: `${loopbackIssuer}/token`,
+        revocation_endpoint: `${loopbackIssuer}/revoke`,
+      }),
+    } as Response);
+    /* eslint-enable @typescript-eslint/naming-convention */
+
+    await assert.isRejected(
+      new OidcDiscoveryCache(loopbackIssuer, cacheDirectory).getConfiguration(),
+      "issuer must use HTTPS",
+    );
+  });
+});

--- a/packages/service/src/test/OIDCDiscoveryClient.test.ts
+++ b/packages/service/src/test/OIDCDiscoveryClient.test.ts
@@ -7,8 +7,6 @@ import * as chai from "chai";
 import type { OIDCConfig } from "../OIDCDiscoveryClient";
 import { OIDCDiscoveryClient } from "../OIDCDiscoveryClient";
 
- // @eslint-disable @typescript-eslint/naming-convention
-
 describe("BaseOpenidClient", () => {
   const testAuthority = "https://test.authority.com";
 

--- a/packages/service/src/test/OIDCDiscoveryClient.test.ts
+++ b/packages/service/src/test/OIDCDiscoveryClient.test.ts
@@ -7,6 +7,8 @@ import * as chai from "chai";
 import type { OIDCConfig } from "../OIDCDiscoveryClient";
 import { OIDCDiscoveryClient } from "../OIDCDiscoveryClient";
 
+ // @eslint-disable @typescript-eslint/naming-convention
+
 describe("BaseOpenidClient", () => {
   const testAuthority = "https://test.authority.com";
 


### PR DESCRIPTION
The [OIDC client configuration endpoint](https://ims.bentley.com/.well-known/openid-configuration) rarely changes and includes a `cache-control` header indicating it's cacheable for 24 hours.

Fetching the configuration values from this endpoint takes ~500-800ms, right in the initial sign-in code path.

- Uses `fetch` for OIDC config so we can get response headers
- Stores the config in Electron safeStorage
- Validates URLs coming from safeStorage to ensure they are valid Bentley endpoints
- Respects `Cache-Control` header values

While this won't have any impact on first-runs of applications (since their cache will be empty) it will improve the performance of auth on subsequent app opens throughout the day.


### Benchmark

Mode | Samples | Mean | p50 | p95
-- | -- | -- | -- | --
Uncached | 10 | 458.81 ms | 468.74 ms | 515.14 ms
Cached | 10 | 4.71 ms | 4.65 ms | 4.77 ms



