### PR TITLE
Remove got from service authorization

### DIFF
--- a/change/@itwin-service-authorization-7f0d7a69-cb3a-4bc4-9cb7-9f4d6a2f8a34.json
+++ b/change/@itwin-service-authorization-7f0d7a69-cb3a-4bc4-9cb7-9f4d6a2f8a34.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove got from service authorization HTTP requests.",
+  "packageName": "@itwin/service-authorization",
+  "email": "aayushtiwari1001@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
   },
   "pnpm": {
     "overrides": {
-      "serialize-javascript@<=7.0.2": ">=7.0.3",
-      "cacheable-request@13.0.20": "13.0.19"
+      "serialize-javascript@<=7.0.2": ">=7.0.3"
     }
   },
   "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531"

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -27,7 +27,6 @@
     "directory": "packages/service"
   },
   "dependencies": {
-    "got": "12.6.1",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.2.0"
   },

--- a/packages/service/src/FetchUtils.ts
+++ b/packages/service/src/FetchUtils.ts
@@ -4,22 +4,64 @@
 *--------------------------------------------------------------------------------------------*/
 
 interface FetchWithRetryOptions {
-  retries: number;
-  timeout: number;
+  retries?: number;
+  requestTimeout?: number;
+  retryDelay?: number;
 }
 
+const defaultFetchWithRetryOptions: Required<FetchWithRetryOptions> = {
+  retries: 3,
+  requestTimeout: 12000,
+  retryDelay: 100,
+};
+
 const retryableStatusCodes = new Set([408, 413, 429, 500, 502, 503, 504]);
+
+function getRetryAfterDelay(response: Response): number | undefined {
+  const retryAfter = response.headers.get("Retry-After");
+  if (!retryAfter)
+    return undefined;
+
+  const retryAfterSeconds = Number(retryAfter);
+  if (Number.isFinite(retryAfterSeconds))
+    return Math.max(retryAfterSeconds * 1000, 0);
+
+  const retryAfterDate = Date.parse(retryAfter);
+  if (Number.isFinite(retryAfterDate))
+    return Math.max(retryAfterDate - Date.now(), 0);
+
+  return undefined;
+}
+
+function getRetryDelay(response: Response | undefined, attempt: number, retryDelay: number): number {
+  if (response) {
+    const retryAfterDelay = getRetryAfterDelay(response);
+    if (retryAfterDelay !== undefined)
+      return retryAfterDelay;
+  }
+
+  return retryDelay * 2 ** attempt;
+}
+
+async function delay(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
 
 /**
  * Execute a fetch request with the retry and timeout behavior needed by service authorization.
  * @internal
  */
-export async function fetchWithRetry(input: RequestInfo | URL, init: RequestInit, options: FetchWithRetryOptions): Promise<Response> {
+export async function fetchWithRetry(input: RequestInfo | URL, init: RequestInit, options?: FetchWithRetryOptions): Promise<Response> {
+  const fetchOptions = {
+    ...defaultFetchWithRetryOptions,
+    ...options,
+  };
   let lastError: unknown;
 
-  for (let attempt = 0; attempt <= options.retries; attempt++) {
+  for (let attempt = 0; attempt <= fetchOptions.retries; attempt++) {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), options.timeout);
+    const timeout = setTimeout(() => controller.abort(), fetchOptions.requestTimeout);
+    let retryResponse: Response | undefined;
 
     try {
       const response = await fetch(input, {
@@ -27,17 +69,20 @@ export async function fetchWithRetry(input: RequestInfo | URL, init: RequestInit
         signal: controller.signal,
       });
 
-      if (!retryableStatusCodes.has(response.status) || attempt === options.retries)
+      if (!retryableStatusCodes.has(response.status) || attempt === fetchOptions.retries)
         return response;
 
+      retryResponse = response;
       await response.body?.cancel();
     } catch (error) {
       lastError = error;
-      if (attempt === options.retries)
+      if (attempt === fetchOptions.retries)
         throw error;
     } finally {
       clearTimeout(timeout);
     }
+
+    await delay(getRetryDelay(retryResponse, attempt, fetchOptions.retryDelay));
   }
 
   throw lastError;

--- a/packages/service/src/FetchUtils.ts
+++ b/packages/service/src/FetchUtils.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+interface FetchWithRetryOptions {
+  retries: number;
+  timeout: number;
+}
+
+const retryableStatusCodes = new Set([408, 413, 429, 500, 502, 503, 504]);
+
+/**
+ * Execute a fetch request with the retry and timeout behavior needed by service authorization.
+ * @internal
+ */
+export async function fetchWithRetry(input: RequestInfo | URL, init: RequestInit, options: FetchWithRetryOptions): Promise<Response> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= options.retries; attempt++) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), options.timeout);
+
+    try {
+      const response = await fetch(input, {
+        ...init,
+        signal: controller.signal,
+      });
+
+      if (!retryableStatusCodes.has(response.status) || attempt === options.retries)
+        return response;
+
+      await response.body?.cancel();
+    } catch (error) {
+      lastError = error;
+      if (attempt === options.retries)
+        throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  throw lastError;
+}

--- a/packages/service/src/OIDCDiscoveryClient.ts
+++ b/packages/service/src/OIDCDiscoveryClient.ts
@@ -80,7 +80,7 @@ export class OIDCDiscoveryClient {
         Accept: "application/json",
         ...additionalHeaders,
       },
-    }, { retries: 3, timeout: 12000 });
+    });
 
     if (!response.ok)
       throw new Error("Failed to retrieve OpenID configuration from authority");

--- a/packages/service/src/OIDCDiscoveryClient.ts
+++ b/packages/service/src/OIDCDiscoveryClient.ts
@@ -3,6 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { URL } from "node:url";
+import { fetchWithRetry } from "./FetchUtils";
 
 const requiredProperties = ["issuer", "authorization_endpoint", "jwks_uri", "response_types_supported", "subject_types_supported", "id_token_signing_alg_values_supported"] as const;
 const stringProperties = ["issuer", "authorization_endpoint", "jwks_uri", "token_endpoint",
@@ -73,19 +74,18 @@ export class OIDCDiscoveryClient {
 
     const issuerUrl = new URL(this.url);
     issuerUrl.pathname = `${issuerUrl.pathname?.replace(/\/$/, "")}/.well-known/openid-configuration`;
-    const response = await (await import("got")).default(issuerUrl, {
+    const response = await fetchWithRetry(issuerUrl, {
       headers: {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         Accept: "application/json",
         ...additionalHeaders,
       },
-      throwHttpErrors: false,
-    });
+    }, { retries: 3, timeout: 12000 });
 
-    if (response.statusCode < 200 || response.statusCode >= 300 || !response.body)
+    if (!response.ok)
       throw new Error("Failed to retrieve OpenID configuration from authority");
 
-    const body = JSON.parse(response.body);
+    const body = await response.json();
     assertOIDCConfig(body);
     return this._discoveredConfig = body;
   }

--- a/packages/service/src/ServiceAuthorizationClient.ts
+++ b/packages/service/src/ServiceAuthorizationClient.ts
@@ -8,9 +8,7 @@
 
 import type { AuthorizationClient } from "@itwin/core-common";
 import type { ServiceAuthorizationClientConfiguration } from "./ServiceAuthorizationClientConfiguration";
-// this is a type-only import, it won't break the resulting .js file.
-// It also won't show up in the resulting .d.ts file because we don't re-export this type.
-import type { Options as GotOptions } from "got" with { "resolution-mode": "import" };
+import { fetchWithRetry } from "./FetchUtils";
 import { OIDCDiscoveryClient } from "./OIDCDiscoveryClient";
 
 /**
@@ -27,24 +25,15 @@ import { OIDCDiscoveryClient } from "./OIDCDiscoveryClient";
 export class ServiceAuthorizationClient implements AuthorizationClient {
   protected _configuration: ServiceAuthorizationClientConfiguration;
   private _discoveryClient: OIDCDiscoveryClient;
-  private _gotOptions: Pick<GotOptions, "retry" | "timeout">;
+  private _fetchOptions: { retries: number, timeout: number };
 
   private _accessToken: string = "";
   private _expiresAt?: Date;
 
   constructor(serviceConfiguration: ServiceAuthorizationClientConfiguration) {
-    this._gotOptions = {
-      retry: {
-        limit: 3,
-        methods: ["GET", "POST"],
-      },
-      timeout: {
-        lookup: 1000, // DNS
-        connect: 1000, // socket connected
-        send: 1000, // writing data to socket
-        response: 10000, // starts when request has been flushed, ends when the headers are received.
-        request: 12000, // global timeout
-      },
+    this._fetchOptions = {
+      retries: 3,
+      timeout: 12000,
     };
 
     this._discoveryClient = new OIDCDiscoveryClient(serviceConfiguration.authority);
@@ -68,8 +57,8 @@ export class ServiceAuthorizationClient implements AuthorizationClient {
     const encoded = `${encodeURIComponent(this._configuration.clientId)}:${encodeURIComponent(this._configuration.clientSecret)}`.replace("%20", "+");
     const authHeader = `Basic ${Buffer.from(encoded).toString("base64")}`;
 
-    const tokenSet = await (await import("got")).default.post(issuer.token_endpoint, {
-      ...this._gotOptions,
+    const response = await fetchWithRetry(issuer.token_endpoint, {
+      method: "POST",
       headers: {
         /* eslint-disable @typescript-eslint/naming-convention */
         "Content-Type": "application/x-www-form-urlencoded",
@@ -77,8 +66,13 @@ export class ServiceAuthorizationClient implements AuthorizationClient {
         ...additionalHeaders,
         /* eslint-enable @typescript-eslint/naming-convention */
       },
-      form: body,
-    }).json<any>();
+      body: new URLSearchParams(body),
+    }, this._fetchOptions);
+
+    if (!response.ok)
+      throw new Error("Failed to retrieve service authorization token");
+
+    const tokenSet = await response.json();
 
     this._accessToken = `${tokenSet.token_type} ${tokenSet.access_token}`;
     if (tokenSet.expires_in)

--- a/packages/service/src/ServiceAuthorizationClient.ts
+++ b/packages/service/src/ServiceAuthorizationClient.ts
@@ -25,17 +25,11 @@ import { OIDCDiscoveryClient } from "./OIDCDiscoveryClient";
 export class ServiceAuthorizationClient implements AuthorizationClient {
   protected _configuration: ServiceAuthorizationClientConfiguration;
   private _discoveryClient: OIDCDiscoveryClient;
-  private _fetchOptions: { retries: number, timeout: number };
 
   private _accessToken: string = "";
   private _expiresAt?: Date;
 
   constructor(serviceConfiguration: ServiceAuthorizationClientConfiguration) {
-    this._fetchOptions = {
-      retries: 3,
-      timeout: 12000,
-    };
-
     this._discoveryClient = new OIDCDiscoveryClient(serviceConfiguration.authority);
     this._configuration = serviceConfiguration;
   }
@@ -67,7 +61,7 @@ export class ServiceAuthorizationClient implements AuthorizationClient {
         /* eslint-enable @typescript-eslint/naming-convention */
       },
       body: new URLSearchParams(body),
-    }, this._fetchOptions);
+    });
 
     if (!response.ok)
       throw new Error("Failed to retrieve service authorization token");

--- a/packages/service/src/test/FetchUtils.test.ts
+++ b/packages/service/src/test/FetchUtils.test.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { use as chaiUse, expect } from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+import * as sinon from "sinon";
+import { fetchWithRetry } from "../FetchUtils";
+chaiUse(chaiAsPromised);
+
+describe("fetchWithRetry", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("returns a successful fetch response without retrying", async () => {
+    const response = new Response("ok", { status: 200 });
+    const fetchStub = sinon.stub(globalThis, "fetch").resolves(response);
+
+    const result = await fetchWithRetry("https://test.example.com", {
+      headers: { accept: "application/json" },
+    });
+
+    expect(result).to.equal(response);
+    expect(fetchStub.callCount).to.equal(1);
+    const [, init] = fetchStub.firstCall.args as [RequestInfo | URL, RequestInit];
+    expect(init.headers).to.deep.equal({ accept: "application/json" });
+    expect(init.signal).to.be.instanceOf(AbortSignal);
+  });
+
+  it("honors Retry-After before retrying a retryable response", async () => {
+    const clock = sinon.useFakeTimers();
+    const retryResponse = new Response("rate limited", {
+      status: 429,
+      headers: { "Retry-After": "1" },
+    });
+    const successResponse = new Response("ok", { status: 200 });
+    const fetchStub = sinon.stub(globalThis, "fetch");
+    fetchStub.onFirstCall().resolves(retryResponse);
+    fetchStub.onSecondCall().resolves(successResponse);
+
+    const request = fetchWithRetry("https://test.example.com", {}, {
+      requestTimeout: 12000,
+      retries: 1,
+      retryDelay: 10,
+    });
+
+    await clock.tickAsync(999);
+    expect(fetchStub.callCount).to.equal(1);
+
+    await clock.tickAsync(1);
+    const result = await request;
+
+    expect(result).to.equal(successResponse);
+    expect(fetchStub.callCount).to.equal(2);
+  });
+
+  it("throws the last fetch error after retry attempts are exhausted", async () => {
+    const clock = sinon.useFakeTimers();
+    const firstError = new Error("temporary failure");
+    const lastError = new Error("still failing");
+    const fetchStub = sinon.stub(globalThis, "fetch");
+    fetchStub.onFirstCall().rejects(firstError);
+    fetchStub.onSecondCall().rejects(lastError);
+
+    const request = fetchWithRetry("https://test.example.com", {}, {
+      requestTimeout: 12000,
+      retries: 1,
+      retryDelay: 10,
+    });
+
+    await clock.tickAsync(10);
+
+    await expect(request).to.be.rejectedWith("still failing");
+    expect(fetchStub.callCount).to.equal(2);
+  });
+});

--- a/packages/service/src/test/ServiceAuthorizationClient.test.ts
+++ b/packages/service/src/test/ServiceAuthorizationClient.test.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+import type { OIDCConfig } from "../OIDCDiscoveryClient";
+import { OIDCDiscoveryClient } from "../OIDCDiscoveryClient";
+import { ServiceAuthorizationClient } from "../ServiceAuthorizationClient";
+
+describe("ServiceAuthorizationClient", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should request a service token using fetch", async () => {
+    /* eslint-disable @typescript-eslint/naming-convention */
+    sinon.stub(OIDCDiscoveryClient.prototype, "getConfig").resolves({
+      token_endpoint: "https://test.authority.com/connect/token",
+    } as OIDCConfig);
+
+    const fetchStub = sinon.stub(globalThis, "fetch").resolves(new Response(JSON.stringify({
+      access_token: "test-token",
+      expires_in: 3600,
+      token_type: "Bearer",
+    })));
+
+    const client = new ServiceAuthorizationClient({
+      authority: "https://test.authority.com",
+      clientId: "client id",
+      clientSecret: "client-secret",
+      scope: "scope-a scope-b",
+    });
+
+    const token = await client.getAccessToken({ "X-Test": "test-header" });
+
+    expect(token).to.equal("Bearer test-token");
+    expect(fetchStub.callCount).to.equal(1);
+
+    const [url, init] = fetchStub.firstCall.args as [string, RequestInit];
+    expect(url).to.equal("https://test.authority.com/connect/token");
+    expect(init.method).to.equal("POST");
+    expect(init.headers).to.deep.equal({
+      "Content-Type": "application/x-www-form-urlencoded",
+      "Authorization": `Basic ${Buffer.from("client+id:client-secret").toString("base64")}`,
+      "X-Test": "test-header",
+    });
+    /* eslint-enable @typescript-eslint/naming-convention */
+
+    const body = init.body as URLSearchParams;
+    expect(body.get("grant_type")).to.equal("client_credentials");
+    expect(body.get("scope")).to.equal("scope-a scope-b");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   serialize-javascript@<=7.0.2: '>=7.0.3'
-  cacheable-request@13.0.20: 13.0.19
 
 importers:
 
@@ -316,9 +315,6 @@ importers:
 
   packages/service:
     dependencies:
-      got:
-        specifier: 12.6.1
-        version: 12.6.1
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.3
@@ -969,10 +965,6 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@sindresorhus/is@5.6.0':
-    resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
-    engines: {node: '>=14.16'}
-
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
 
@@ -981,10 +973,6 @@ packages:
 
   '@sinonjs/samsam@10.0.2':
     resolution: {integrity: sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==}
-
-  '@szmarczak/http-timer@5.0.1':
-    resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
-    engines: {node: '>=14.16'}
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
@@ -1010,9 +998,6 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
-
-  '@types/http-cache-semantics@4.2.0':
-    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
 
   '@types/jquery@3.5.34':
     resolution: {integrity: sha512-3m3939S3erqmTLJANS/uy0B6V7BorKx7RorcGZVjZ62dF5PAGbKEDZK1CuLtKombJkFA2T1jl8LAIIs7IV6gBQ==}
@@ -1343,14 +1328,6 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
-  cacheable-lookup@7.0.0:
-    resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
-    engines: {node: '>=14.16'}
-
-  cacheable-request@10.2.14:
-    resolution: {integrity: sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==}
-    engines: {node: '>=14.16'}
-
   caching-transform@4.0.0:
     resolution: {integrity: sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==}
     engines: {node: '>=8'}
@@ -1546,10 +1523,6 @@ packages:
     resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
     engines: {node: '>=10'}
 
-  decompress-response@6.0.0:
-    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
-    engines: {node: '>=10'}
-
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
@@ -1568,10 +1541,6 @@ packages:
   default-require-extensions@3.0.1:
     resolution: {integrity: sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==}
     engines: {node: '>=8'}
-
-  defer-to-connect@2.0.1:
-    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
-    engines: {node: '>=10'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -1978,10 +1947,6 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data-encoder@2.1.4:
-    resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
-    engines: {node: '>= 14.17'}
-
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
@@ -2154,10 +2119,6 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
-  got@12.6.1:
-    resolution: {integrity: sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==}
-    engines: {node: '>=14.16'}
-
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -2207,16 +2168,9 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  http-cache-semantics@4.2.0:
-    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
-
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
-
-  http2-wrapper@2.2.1:
-    resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
-    engines: {node: '>=10.19.0'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -2717,10 +2671,6 @@ packages:
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
-  lowercase-keys@3.0.0:
-    resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -2822,14 +2772,6 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
-  mimic-response@3.1.0:
-    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
-    engines: {node: '>=10'}
-
-  mimic-response@4.0.0:
-    resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   minimatch@10.2.3:
     resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
     engines: {node: 18 || 20 || >=22}
@@ -2903,10 +2845,6 @@ packages:
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
-
-  normalize-url@8.1.1:
-    resolution: {integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==}
-    engines: {node: '>=14.16'}
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -2987,10 +2925,6 @@ packages:
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
-
-  p-cancelable@3.0.0:
-    resolution: {integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==}
-    engines: {node: '>=12.20'}
 
   p-graph@1.3.0:
     resolution: {integrity: sha512-QL8xXlJl/oWWbzQK0de3KMFDzCXF8SQ2medloXxRFI1GUjNFBHiOtNv7X1azGBzF1SolIhm+gZ5XshBo6+3sdw==}
@@ -3181,10 +3115,6 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  quick-lru@5.1.1:
-    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
-    engines: {node: '>=10'}
-
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -3227,9 +3157,6 @@ packages:
     resolution: {integrity: sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==}
     engines: {node: '>=0.10.5'}
 
-  resolve-alpn@1.2.1:
-    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
-
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3247,10 +3174,6 @@ packages:
     resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
     engines: {node: '>= 0.4'}
     hasBin: true
-
-  responselike@3.0.0:
-    resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
-    engines: {node: '>=14.16'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -4390,8 +4313,6 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@sindresorhus/is@5.6.0': {}
-
   '@sinonjs/commons@3.0.1':
     dependencies:
       type-detect: 4.0.8
@@ -4404,10 +4325,6 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
       type-detect: 4.1.0
-
-  '@szmarczak/http-timer@5.0.1':
-    dependencies:
-      defer-to-connect: 2.0.1
 
   '@types/argparse@1.0.38': {}
 
@@ -4430,8 +4347,6 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
-
-  '@types/http-cache-semantics@4.2.0': {}
 
   '@types/jquery@3.5.34':
     dependencies:
@@ -4811,18 +4726,6 @@ snapshots:
 
   bytes@3.1.2: {}
 
-  cacheable-lookup@7.0.0: {}
-
-  cacheable-request@10.2.14:
-    dependencies:
-      '@types/http-cache-semantics': 4.2.0
-      get-stream: 6.0.1
-      http-cache-semantics: 4.2.0
-      keyv: 4.5.4
-      mimic-response: 4.0.0
-      normalize-url: 8.1.1
-      responselike: 3.0.0
-
   caching-transform@4.0.0:
     dependencies:
       hasha: 5.2.2
@@ -5022,10 +4925,6 @@ snapshots:
 
   decamelize@4.0.0: {}
 
-  decompress-response@6.0.0:
-    dependencies:
-      mimic-response: 3.1.0
-
   deep-eql@4.1.4:
     dependencies:
       type-detect: 4.1.0
@@ -5042,8 +4941,6 @@ snapshots:
   default-require-extensions@3.0.1:
     dependencies:
       strip-bom: 4.0.0
-
-  defer-to-connect@2.0.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -5632,8 +5529,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data-encoder@2.1.4: {}
-
   form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
@@ -5814,20 +5709,6 @@ snapshots:
 
   gopd@1.2.0: {}
 
-  got@12.6.1:
-    dependencies:
-      '@sindresorhus/is': 5.6.0
-      '@szmarczak/http-timer': 5.0.1
-      cacheable-lookup: 7.0.0
-      cacheable-request: 10.2.14
-      decompress-response: 6.0.0
-      form-data-encoder: 2.1.4
-      get-stream: 6.0.1
-      http2-wrapper: 2.2.1
-      lowercase-keys: 3.0.0
-      p-cancelable: 3.0.0
-      responselike: 3.0.0
-
   graceful-fs@4.2.11: {}
 
   has-bigints@1.1.0: {}
@@ -5867,8 +5748,6 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  http-cache-semantics@4.2.0: {}
-
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -5876,11 +5755,6 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
-
-  http2-wrapper@2.2.1:
-    dependencies:
-      quick-lru: 5.1.1
-      resolve-alpn: 1.2.1
 
   human-signals@2.1.0: {}
 
@@ -6354,8 +6228,6 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
-  lowercase-keys@3.0.0: {}
-
   lru-cache@10.4.3: {}
 
   lru-cache@11.2.7: {}
@@ -6438,10 +6310,6 @@ snapshots:
   mimic-fn@4.0.0: {}
 
   mimic-function@5.0.1: {}
-
-  mimic-response@3.1.0: {}
-
-  mimic-response@4.0.0: {}
 
   minimatch@10.2.3:
     dependencies:
@@ -6528,8 +6396,6 @@ snapshots:
       process-on-spawn: 1.1.0
 
   node-releases@2.0.36: {}
-
-  normalize-url@8.1.1: {}
 
   npm-run-path@4.0.1:
     dependencies:
@@ -6656,8 +6522,6 @@ snapshots:
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
-
-  p-cancelable@3.0.0: {}
 
   p-graph@1.3.0: {}
 
@@ -6824,8 +6688,6 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  quick-lru@5.1.1: {}
-
   range-parser@1.2.1: {}
 
   raw-body@2.5.3:
@@ -6871,8 +6733,6 @@ snapshots:
 
   requireindex@1.1.0: {}
 
-  resolve-alpn@1.2.1: {}
-
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -6891,10 +6751,6 @@ snapshots:
       object-keys: 1.1.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-
-  responselike@3.0.0:
-    dependencies:
-      lowercase-keys: 3.0.0
 
   reusify@1.1.0: {}
 


### PR DESCRIPTION
## Summary
- Replace @itwin/service-authorization got usage with a small fetch-based helper that preserves retry and request timeout behavior.
- Remove the got dependency and the cacheable-request pnpm override/lockfile entries.
- Add focused coverage for the service token POST request using fetch.

Fixes #357.

## Validation
- corepack pnpm --filter @itwin/service-authorization run build
- corepack pnpm --filter @itwin/service-authorization run lint (passes with existing Introspection.test.ts unused eslint-disable warning)
- corepack pnpm --filter @itwin/service-authorization run test (14 passing)
- corepack pnpm run check